### PR TITLE
Remove type annotation on last argument of ustrip methods

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -25,8 +25,8 @@ julia> ustrip(Float64, u"m", 2u"mm") == 0.002
 true
 ```
 """
-@inline ustrip(u::Units, x::Quantity) = ustrip(uconvert(u, x))
-@inline ustrip(T::Type, u::Units, x::Quantity) = convert(T, ustrip(u, x))
+@inline ustrip(u::Units, x) = ustrip(uconvert(u, x))
+@inline ustrip(T::Type, u::Units, x) = convert(T, ustrip(u, x))
 
 """
     ustrip(x::Number)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,8 +86,15 @@ end
         @test @inferred(ustrip(m, 3.0m)) === 3.0
         @test @inferred(ustrip(m, 2mm)) === 1//500
         @test @inferred(ustrip(mm, 3.0m)) === 3000.0
+        @test @inferred(ustrip(NoUnits, 3.0m/1.0m)) === 3.0
+        @test @inferred(ustrip(NoUnits, 3.0m/1.0cm)) === 300.0
+        @test @inferred(ustrip(cm, missing)) === missing
+        @test @inferred(ustrip(NoUnits, missing)) === missing
+        @test_throws DimensionError ustrip(NoUnits, 3.0m/1.0s)
         @test @inferred(ustrip(Float64, m, 2mm)) === 0.002
         @test @inferred(ustrip(Int, mm, 2.0m)) === 2000
+        @test @inferred(ustrip(Float32, NoUnits, 5.0u"m"/2.0u"m")) === Float32(2.5)
+        @test @inferred(ustrip(Int, NoUnits, 3.0u"m"/1.0u"cm")) === 300
         # convert
         @test convert(typeof(1mm/m), 3) == 3000mm/m
         @test convert(typeof(1mm/m), 3*NoUnits) == 3000mm/m


### PR DESCRIPTION
<s>With the new safe `ustrip(unit, quantity)` method (which I like!) it's not possible to do something like `ustrip(NoUnits, 3.0m/1.0m)` (which, I think, should be safe enough).  I've added another method to make `ustrip(NoUnits, 3.0m/1.0cm)` fail, since it would be unsafe</s>

This enables using this function on dimensionless quantitites and missing objects too.