### PR TITLE
Add show method for MIME"text/plain"

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -62,6 +62,14 @@ function show(io::IO, x::Quantity)
     nothing
 end
 
+function show(io::IO, mime::MIME"text/plain", x::Quantity)
+    show(io, mime, x.val)
+    if !isunitless(unit(x))
+        print(io," ")
+        show(io, mime, unit(x))
+    end
+end
+
 function show(io::IO, x::Quantity{S, NoDims, <:Units{
     (Unitful.Unit{:Degree, NoDims}(0, 1//1),), NoDims}}) where S
     show(io, x.val)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1138,6 +1138,17 @@ end
     @test string(NoDims) == "NoDims"
 end
 
+struct Foo <: Number end
+Base.show(io::IO, x::Foo) = print(io, "1")
+Base.show(io::IO, ::MIME"text/plain", ::Foo) = print(io, "42.0")
+
+@testset "Show quantities" begin
+    @test repr(1.0 * u"m * s * kg^-1") == "1.0 m s kg^-1"
+    @test repr("text/plain", 1.0 * u"m * s * kg^-1") == "1.0 m s kg^-1"
+    @test repr(Foo() * u"m * s * kg^-1") == "1 m s kg^-1"
+    @test repr("text/plain", Foo() * u"m * s * kg^-1") == "42.0 m s kg^-1"
+end
+
 @testset "DimensionError message" begin
     function errorstr(e)
         b = IOBuffer()


### PR DESCRIPTION
Add a `show` method to print the value and unit parts in case they have custom representations with MIME `text/plain`