### PR TITLE
Implementation of an Angles Dimension

### DIFF
--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -46,6 +46,7 @@ include("range.jl")
 include("fastmath.jl")
 include("logarithm.jl")
 include("pkgdefaults.jl")
+include("trigonometry.jl")
 
 function __init__()
     # @u_str should be aware of units defined in module Unitful

--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -5,7 +5,8 @@ import Base: show, convert
 import Base: abs, abs2, angle, float, fma, muladd, inv, sqrt, cbrt
 import Base: min, max, floor, ceil, real, imag, conj
 import Base: exp, exp10, exp2, expm1, log, log10, log1p, log2
-import Base: sin, cos, tan, cot, sec, csc, atan, cis
+import Base: sin, cos, tan, csc, sec, cot, cis
+import Base: sind, cosd, tand, cscd, secd, cotd
 
 import Base: eps, mod, rem, div, fld, cld, trunc, round, sign, signbit
 import Base: isless, isapprox, isinteger, isreal, isinf, isfinite, isnan

--- a/src/display.jl
+++ b/src/display.jl
@@ -62,13 +62,6 @@ function show(io::IO, x::Quantity)
     nothing
 end
 
-function show(io::IO, x::Quantity{S, NoDims, <:Units{
-    (Unitful.Unit{:Degree, NoDims}(0, 1//1),), NoDims}}) where S
-    show(io, x.val)
-    show(io, unit(x))
-    nothing
-end
-
 function show(io::IO, x::Type{T}) where T<:Quantity
     invoke(show, Tuple{IO, typeof(x)}, IOContext(io, :showoperators=>true), x)
 end

--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -233,6 +233,10 @@ isrootpower_dim(::typeof(𝐋^3))                  = false     # reflectivity
 isrootpower_dim(::typeof(dimension(Ω)))         = true
 isrootpower_dim(::typeof(dimension(S)))         = true
 isrootpower_dim(::typeof(dimension(Hz)))        = false
+isrootpower_dim(::typeof(dimension(m)))         = false
+isrootpower_dim(::typeof(dimension(s)))         = false
+isrootpower_dim(::typeof(dimension(K)))         = false
+isrootpower_dim(::typeof(dimension(g)))         = false
 
 #########
 

--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -9,6 +9,7 @@
 @dimension 𝚯 "𝚯" Temperature    # This one is \bfTheta
 @dimension 𝐉 "𝐉" Luminosity
 @dimension 𝐍 "𝐍" Amount
+@dimension 𝚽 "𝚽" Angle
 const RelativeScaleTemperature = Quantity{T, 𝚯, <:AffineUnits} where T
 const AbsoluteScaleTemperature = Quantity{T, 𝚯, <:ScalarUnits} where T
 
@@ -46,6 +47,7 @@ const AbsoluteScaleTemperature = Quantity{T, 𝚯, <:ScalarUnits} where T
 @derived_dimension MagneticDipoleMoment     𝐋^2*𝐈
 @derived_dimension Molarity                 𝐍/𝐋^3
 @derived_dimension Molality                 𝐍/𝐌
+@derived_dimension Steradian                𝚽^2
 
 # Define base units. This is not to imply g is the base SI unit instead of kg.
 # See the documentation for further details.
@@ -57,18 +59,11 @@ const AbsoluteScaleTemperature = Quantity{T, 𝚯, <:ScalarUnits} where T
 @refunit  cd      "cd"     Candela   𝐉            true
 @refunit  g       "g"      Gram      𝐌           true
 @refunit  mol     "mol"    Mole      𝐍           true
+@refunit  rad     "rad"    Radian    𝚽           true
 
 # Angles and solid angles
-@unit sr      "sr"      Steradian   1                       true
-@unit rad     "rad"     Radian      1                       true
-@unit °       "°"       Degree      pi/180                  false
-# For numerical accuracy, specific to the degree
-import Base: sind, cosd, tand, secd, cscd, cotd
-for (_x,_y) in ((:sin,:sind), (:cos,:cosd), (:tan,:tand),
-        (:sec,:secd), (:csc,:cscd), (:cot,:cotd))
-    @eval ($_x)(x::Quantity{T, NoDims, typeof(°)}) where {T} = ($_y)(ustrip(x))
-    @eval ($_y)(x::Quantity{T, NoDims, typeof(°)}) where {T} = ($_y)(ustrip(x))
-end
+@unit sr      "sr"      Steradian   1rad^2                  true
+@unit °       "°"       Degree      pi*rad/180              false
 
 # SI and related units
 @unit Hz     "Hz"       Hertz       1/s                     true
@@ -256,7 +251,7 @@ const si_no_prefix = (:m, :s, :A, :K, :g, :mol, :rad, :sr, :Hz, :N, :Pa, #:cd,
 baremodule DefaultSymbols
     import Unitful
 
-    for u in (:𝐋,:𝐌,:𝐓,:𝐈,:𝚯,:𝐉,:𝐍)
+    for u in (:𝐋,:𝐌,:𝐓,:𝐈,:𝚯,:𝐉,:𝐍,:𝚽)
         Core.eval(DefaultSymbols, Expr(:import, Expr(:(.), :Unitful, u)))
         Core.eval(DefaultSymbols, Expr(:export, u))
     end

--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -47,7 +47,7 @@ const AbsoluteScaleTemperature = Quantity{T, 𝚯, <:ScalarUnits} where T
 @derived_dimension MagneticDipoleMoment     𝐋^2*𝐈
 @derived_dimension Molarity                 𝐍/𝐋^3
 @derived_dimension Molality                 𝐍/𝐌
-@derived_dimension Steradian                𝚽^2
+#TODO: add in derived angular dimensions (like angular momentum, velocity, ...)
 
 # Define base units. This is not to imply g is the base SI unit instead of kg.
 # See the documentation for further details.

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -70,10 +70,6 @@ for f in (:mod, :rem)
     end
 end
 
-Base.mod2pi(x::DimensionlessQuantity) = mod2pi(uconvert(NoUnits, x))
-Base.mod2pi(x::AbstractQuantity{S, NoDims, <:Units{(Unitful.Unit{:Degree, NoDims}(0, 1//1),),
-    NoDims}}) where S = mod(x, 360°)
-
 # Addition / subtraction
 for op in [:+, :-]
     @eval ($op)(x::AbstractQuantity{S,D,U}, y::AbstractQuantity{T,D,U}) where {S,T,D,U} =
@@ -159,15 +155,6 @@ end
 sqrt(x::AbstractQuantity) = Quantity(sqrt(x.val), sqrt(unit(x)))
 cbrt(x::AbstractQuantity) = Quantity(cbrt(x.val), cbrt(unit(x)))
 
-for _y in (:sin, :cos, :tan, :cot, :sec, :csc, :cis)
-    @eval ($_y)(x::DimensionlessQuantity) = ($_y)(uconvert(NoUnits, x))
-end
-
-atan(y::AbstractQuantity, x::AbstractQuantity) = atan(promote(y,x)...)
-atan(y::AbstractQuantity{T,D,U}, x::AbstractQuantity{T,D,U}) where {T,D,U} = atan(y.val,x.val)
-atan(y::AbstractQuantity{T,D1,U1}, x::AbstractQuantity{T,D2,U2}) where {T,D1,U1,D2,U2} =
-    throw(DimensionError(x,y))
-
 for (f, F) in [(:min, :<), (:max, :>)]
     @eval @generated function ($f)(x::AbstractQuantity, y::AbstractQuantity)    #TODO
         xdim = x.parameters[2]
@@ -203,7 +190,6 @@ end
 
 abs(x::AbstractQuantity) = Quantity(abs(x.val), unit(x))
 abs2(x::AbstractQuantity) = Quantity(abs2(x.val), unit(x)*unit(x))
-angle(x::AbstractQuantity{<:Complex}) = angle(x.val)
 
 copysign(x::AbstractQuantity, y::Number) = Quantity(copysign(x.val,y/unit(y)), unit(x))
 flipsign(x::AbstractQuantity, y::Number) = Quantity(flipsign(x.val,y/unit(y)), unit(x))

--- a/src/trigonometry.jl
+++ b/src/trigonometry.jl
@@ -1,0 +1,55 @@
+using Unitful: rad, °, 𝚽, AbstractQuantity
+
+export atan_°,  asin_°,  acos_°,  asinh_°,  acosh_°,
+       atan_rad,asin_rad,acos_rad,asinh_rad,acosh_rad
+
+# unable to dispatch on this now that D is not of NoDims until the unit
+# has been declared (in pkgdefaults.jl)
+function show(io::IO, x::Quantity{T,D,typeof(°)}) where {T,D}
+    show(io, x.val)
+    show(io, unit(x))
+    nothing
+end
+
+import Base.mod2pi
+mod2pi(x::DimensionlessQuantity) = mod2pi(uconvert(NoUnits, x))
+mod2pi(x::Quantity{T,𝚽,typeof(rad)}) where T = deg2rad(mod(rad2deg(x.val), 360))rad
+mod2pi(x::Quantity{T,𝚽,typeof(°)}) where T = mod(x, 360°)
+
+## For numerical accuracy, specific to the degree
+# _r radian form, _d degree form
+for (_r,_d) in ((:sin,:sind),(:cos,:cosd),(:tan,:tand),(:sec,:secd),(:csc,:cscd),(:cot,:cotd))
+    @eval import Base: $_r, $_d
+    # calling radian form with radians
+    @eval $_r(x::Quantity{T, 𝚽, typeof(rad)}) where T = $_d(rad2deg(x.val))
+    # calling degree form with degrees
+    @eval $_d(x::Quantity{T, 𝚽, typeof(°)}) where T = $_d(x.val)
+    # calling radian form with degrees
+    @eval $_r(x::Quantity{T, 𝚽, typeof(°)}) where T = $_d(x.val)
+    # calling degree form with radians
+    @eval $_d(x::Quantity{T, 𝚽, typeof(rad)}) where T = $_d(rad2deg(x.val))
+end
+
+import Base.cis
+cis(x::Quantity{T, 𝚽, U}) where {T,U} = cos(x) + im*sin(x)
+
+import Base: atan, asin, acos, asinh, acosh
+atan(y::AbstractQuantity, x::AbstractQuantity) = atan(promote(y,x)...)
+atan(y::AbstractQuantity{T,D,U}, x::AbstractQuantity{T,D,U}) where {T,D,U} = atan(y.val,x.val)
+atan(y::AbstractQuantity{T,D1,U1}, x::AbstractQuantity{T,D2,U2}) where {T,D1,U1,D2,U2} =
+    throw(DimensionError(x,y))
+atan_rad(y,x) = atan(y,x)rad
+atan_°(y,x) = rad2deg(atan(y,x))°
+
+for _x in (:asin, :acos, :asinh, :acosh)
+    _r = Symbol(_x,:_rad)
+    _d = Symbol(_x,:_°)
+    @eval $_r(x) = $_x(x)rad
+    @eval $_d(x) = rad2deg($_x(x))°
+end
+
+angle(x::AbstractQuantity{<:Complex}) = angle(x.val)rad
+
+import Base.*
+*(x::Quantity{S,𝚽,typeof(rad)}, y::Quantity{T,𝐋,U}) where {S,T,U} = x.val*y
+*(x::Quantity{S,𝐋,U}, y::Quantity{T,𝚽,typeof(rad)}) where {S,T,U} = y.val*x

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ import Unitful:
     ac,
     mg, g, kg,
     Ra, °F, °C, K,
-    rad, °,
+    mrad, rad, °,
     ms, s, minute, hr, Hz,
     J, A, N, mol, cd, V,
     mW, W,
@@ -305,13 +305,13 @@ end
         @test @inferred(promote(1.0m, 1kg)) === (1.0m, 1.0kg)
         @test @inferred(promote(1kg, 1.0m)) === (1.0kg, 1.0m)
         @test_broken @inferred(promote(1.0m, 1)) === (1.0m, 1.0)         # issue 52
-        @test @inferred(promote(π, 180°)) === (float(π), float(π))       # issue 168
-        @test @inferred(promote(180°, π)) === (float(π), float(π))       # issue 168
+        @test @inferred(promote(π*rad, 180°)) === (float(π*rad), float(π*rad))
+        @test @inferred(promote(180°, π*rad)) === (float(π*rad), float(π*rad))
 
         # prefer no units for dimensionless numbers
         @test @inferred(promote(1.0mm/m, 1.0km/m)) === (0.001,1000.0)
         @test @inferred(promote(1.0cm/m, 1.0mm/m, 1.0km/m)) === (0.01,0.001,1000.0)
-        @test @inferred(promote(1.0rad,1.0°)) === (1.0,π/180.0)
+        @test @inferred(promote(1.0mrad/rad, 180.0°/(π*rad))) === (0.001,1.0)
 
         # Quantities with promotion context
         # Context overrides free units
@@ -481,8 +481,8 @@ end
         @test @inferred(zero(1m)) === 0m                # Additive identity
         @test @inferred(zero(typeof(1m))) === 0m
         @test @inferred(zero(typeof(1.0m))) === 0.0m
-        @test @inferred(π/2*u"rad" + 90u"°") ≈ π        # Dimless quantities
-        @test @inferred(π/2*u"rad" - 90u"°") ≈ 0        # Dimless quantities
+        @test @inferred(π/2*u"rad" + 90u"°") ≈ π*u"rad" # "Dimless" quantities
+        @test @inferred(π/2*u"rad" - 90u"°") ≈ 0*u"rad" # Dimless quantities
         @test_throws DimensionError 1+1m                # Dim mismatched
         @test_throws DimensionError 1-1m
     end
@@ -577,7 +577,7 @@ end
         @test @inferred(csc(90°)) == 1
         @test @inferred(sec(0°)) == 1
         @test @inferred(cot(45°)) == 1
-        @test @inferred(atan(m*sqrt(3),1m)) ≈ 60°
+        @test @inferred(atan_°(m*sqrt(3),1m)) ≈ 60°
         @test @inferred(angle((3im)*V)) ≈ 90°
     end
     @testset "> Exponentials and logarithms" begin
@@ -956,13 +956,13 @@ end
             @test isa(@inferred(colon(1.0m, 1m, 5m)), StepRangeLen{typeof(1.0m)})
             @test @inferred(length(1.0m:1m:5m)) === 5
             @test @inferred(step(1.0m:1m:5m)) === 1.0m
-            @test @inferred(length(0:10°:360°)) == 37 # issue 111
-            @test @inferred(length(0.0:10°:2pi)) == 37 # issue 111 fallout
-            @test @inferred(last(0°:0.1:360°)) === 6.2 # issue 111 fallout
+            @test @inferred(length(0°:10°:360°)) == 37 # issue 111
+            @test @inferred(length(0rad:10°:2pi*rad)) == 37 # issue 111 fallout
+            @test @inferred(last(0°:0.1rad:360°)) === 6.2rad # issue 111 fallout
             @test @inferred(first(range(1mm, step=0.1mm, length=50))) === 1.0mm # issue 111
             @test @inferred(step(range(1mm, step=0.1mm, length=50))) === 0.1mm # issue 111
-            @test @inferred(last(range(0, step=10°, length=37))) == 2pi
-            @test @inferred(last(range(0°, step=2pi/36, length=37))) == 2pi
+            @test @inferred(last(range(0°, step=10°, length=37))) == 2pi*rad
+            @test @inferred(last(range(0°, step=rad*2pi/36, length=37))) == 2pi*rad
             @test step(range(1.0m, step=1m, length=5)) === 1.0m
             @test_throws DimensionError range(1.0m, step=1.0V, length=5)
             @test_throws ArgumentError 1.0m:0.0m:5.0m

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1187,6 +1187,10 @@ end
         @testset ">> MixedUnits" begin
             @test dBm === MixedUnits{Level{Decibel, 1mW}}()
             @test dBm/Hz === MixedUnits{Level{Decibel, 1mW}}(Hz^-1)
+            @test (@B 10m/m) == 10m
+            @test (@B 10s/s) == 10s
+            @test (@B 10K/K) == 10K
+            @test (@B 10g/g) == 10g
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -577,7 +577,7 @@ end
         @test @inferred(csc(90°)) == 1
         @test @inferred(sec(0°)) == 1
         @test @inferred(cot(45°)) == 1
-        @test @inferred(atan_°(m*sqrt(3),1m)) ≈ 60°
+        @test @inferred(Unitful.atand(m*sqrt(3),1m)) ≈ 60°
         @test @inferred(angle((3im)*V)) ≈ 90°
     end
     @testset "> Exponentials and logarithms" begin
@@ -766,7 +766,7 @@ end
                 @test isapprox((@eval @fastmath $f($third)), (@eval $f($third)))
             end
             for f in (:+, :-, :*, :/, :%, :(==), :!=, :<, :<=, :>, :>=,
-                      :atan, :hypot, :max, :min)
+                      :(Unitful.atan), :hypot, :max, :min)
                 @test isapprox((@eval @fastmath $f($half, $third)),
                                (@eval $f($half, $third)))
                 @test isapprox((@eval @fastmath $f($third, $half)),


### PR DESCRIPTION
I've implemented an Angles Dimension.  This means that angles are no longer treated as dimensionless units.  I think there is a strong case to be made that if `Mole` is a dimensional unit then `Radian` is as well.

This opens up the ability to create derived dimensions for angular quantities like momentum, velocity, . . . and also torque.

Some of the features
```julia
julia> using Unitful

julia> u = Unitful
Unitful

julia> a = 0.5u.rad
0.5 rad

julia> b = uconvert(u.°,a)
28.64788975654116°

julia> sin(a) == sin(b)
true

julia> sind(a) == sind(b)
true

julia> sin(a) == sind(b)
true

julia> sin(a)
0.479425538604203

julia> sind(a)
0.479425538604203

julia> sin(b)
0.479425538604203

julia> sind(b)
0.479425538604203
```
The inverse functions (non-exported due to name conflicts) actually return the correct units.
```julia
julia> u.asin(sqrt(2)/2)
0.7853981633974484 rad

julia> u.asind(sqrt(2)/2)
45.00000000000001°
```
Dispatch on `Angle` quantities is consistent with other dimensions.
```julia
julia> f(x::u.Angle) = sin(x) + 2
f (generic function with 1 method)

julia> f(a)
2.479425538604203

julia> f(1)
ERROR: MethodError: no method matching f(::Int64)
Closest candidates are:
  f(::Union{Quantity{T,𝚽,U}, Level{L,S,Quantity{T,𝚽,U}} where S where L} where U where T) at REPL[26]:1
Stacktrace:
 [1] top-level scope at none:0
```
Currently radians drop only when they encounter a quantity with a length dimension via multiplication such that
```julia
julia> a
0.5 rad

julia> a*1u"m"
0.5 m

julia> a*1u"m"^2
0.5 m^2 rad

julia> a/1u"m"
0.5 rad m^-1
```