### PR TITLE
Update Readme's badges and CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![Build Status](https://travis-ci.org/ajkeller34/Unitful.jl.svg?branch=master)](https://travis-ci.org/ajkeller34/Unitful.jl)
-[![Build Status](https://ci.appveyor.com/api/projects/status/eo2upsvc9k4gd6bk?svg=true)](https://ci.appveyor.com/project/ajkeller34/unitful-jl)
-[![Coverage Status](https://coveralls.io/repos/github/ajkeller34/Unitful.jl/badge.svg?branch=master)](https://coveralls.io/github/ajkeller34/Unitful.jl?branch=master)
-[![codecov.io](http://codecov.io/github/ajkeller34/Unitful.jl/coverage.svg?branch=master)](http://codecov.io/github/ajkeller34/Unitful.jl?branch=master)
+[![Build Status](https://travis-ci.org/painterqubits/Unitful.jl.svg?branch=master)](https://travis-ci.org/painterqubits/Unitful.jl)
+[![Build Status](https://ci.appveyor.com/api/projects/status/eo2upsvc9k4gd6bk?svg=true)](https://ci.appveyor.com/project/painterqubits/unitful-jl)
+[![Coverage Status](https://coveralls.io/repos/github/painterqubits/Unitful.jl/badge.svg?branch=master)](https://coveralls.io/github/painterqubits/Unitful.jl?branch=master)
+[![codecov.io](http://codecov.io/github/painterqubits/Unitful.jl/coverage.svg?branch=master)](http://codecov.io/github/painterqubits/Unitful.jl?branch=master)
 
-[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://ajkeller34.github.io/Unitful.jl/stable)
-[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://ajkeller34.github.io/Unitful.jl/latest)
+[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://painterqubits.github.io/Unitful.jl/stable)
+[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://painterqubits.github.io/Unitful.jl/latest)
 
 # Unitful.jl
 
@@ -16,8 +16,8 @@ mathematical operations and collections that are found in Julia base.
 
 ## Documentation
 
-[Stable](http://ajkeller34.github.io/Unitful.jl/stable) and
-[latest](https://ajkeller34.github.io/Unitful.jl/latest) versions available.
+[Stable](http://painterqubits.github.io/Unitful.jl/stable) and
+[latest](https://painterqubits.github.io/Unitful.jl/latest) versions available.
 
 ## Other packages in the Unitful family
 


### PR DESCRIPTION
The first commit updates Unitful's badges and links for its documentation to point to PainterQubits.

Also tried to update the badges for Travis, Appveyor, Codecov, and Coveralls, but I think those need to be set up on PainterQubits side. This probably means a few more changes to make these badges reflect the package's status properly.