### PR TITLE
Fix issue #232.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,10 @@ notifications:
 #   allow_failures:
 #   - julia: nightly
 # uncomment the following lines to override the default test script
-# script:
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("Unitful"); Pkg.test("Unitful"; coverage=true)'
+script:
+  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+  - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("Unitful"); Pkg.test("Unitful"; coverage=true)'
+  - julia --compiled-modules=no -e 'using Pkg; Pkg.test("Unitful"; coverage=false)'
 after_success:
   # push coverage results to Coveralls
   - julia -e 'using Pkg; cd(Pkg.dir("Unitful")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/src/logarithm.jl
+++ b/src/logarithm.jl
@@ -1,23 +1,9 @@
-struct IsRootPowerRatio{S,T}
-    val::T
-end
-IsRootPowerRatio{S}(x) where {S} = IsRootPowerRatio{S, typeof(x)}(x)
-Base.show(io::IO, x::IsRootPowerRatio{S}) where {S} =
-    print(io, ifelse(S, "root-power ratio", "power ratio"), " with reference ", x.val)
-const PowerRatio{T} = IsRootPowerRatio{false,T}
-const RootPowerRatio{T} = IsRootPowerRatio{true,T}
-dimension(x::IsRootPowerRatio{S,T}) where {S,T} = dimension(T)
-unwrap(x::IsRootPowerRatio) = x.val
-unwrap(x) = x
-
 base(::LogInfo{N,B}) where {N,B} = B
 prefactor(::LogInfo{N,B,P}) where {N,B,P} = P
 zero(x::T) where {T<:Level} = T(zero(x.val))
 zero(::Type{X}) where {L,S,T,X<:Level{L,S,T}} = X(zero(T))
 one(x::T) where {T<:Level} = one(x.val)
 one(::Type{X}) where {L,S,T,X<:Level{L,S,T}} = one(T)
-dimension(x::Level) = dimension(reflevel(x))
-dimension(x::Type{T}) where {T<:Level} = dimension(reflevel(T))
 function Base.float(x::Level{L,S}) where {L,S}
     v = float(x.val)
     return Level{L,S,typeof(v)}(v)
@@ -35,24 +21,6 @@ Base.convert(::Type{Quantity{T}}, x::Level) where {T<:Number} = convert(Quantity
 Base.convert(::Type{T}, x::Quantity) where {L,S,T<:Level{L,S}} = T(x)
 Base.convert(::Type{T}, x::Level) where {T<:Real} = T(x.val)
 
-"""
-    reflevel(x::Level{L,S})
-    reflevel(::Type{Level{L,S}})
-    reflevel(::Type{Level{L,S,T}})
-Returns the reference level, e.g.
-
-```jldoctest
-julia> reflevel(3u"dBm")
-1 mW
-```
-"""
-function reflevel end
-reflevel(x::Level{L,S}) where {L,S} = unwrap(S)
-reflevel(::Type{Level{L,S}}) where {L,S} = unwrap(S)
-reflevel(::Type{Level{L,S,T}}) where {L,S,T} = unwrap(S)
-
-dimension(x::Gain) = NoDims
-dimension(x::Type{<:Gain}) = NoDims
 function Base.float(x::Gain{L,S}) where {L,S}
     v = float(x.val)
     return Gain{L,S,typeof(v)}(v)
@@ -127,7 +95,6 @@ end
 abbr(::MixedUnits{L}) where {L <: Level} = abbr(L(reflevel(L)))
 abbr(::MixedUnits{L}) where {L <: Gain} = abbr(L(1))
 
-dimension(a::MixedUnits{L}) where {L} = dimension(L) * dimension(a.units)
 unit(a::MixedUnits{L,U}) where {L,U} = U()
 logunit(a::MixedUnits{L}) where {L} = MixedUnits{L}()
 isunitless(::MixedUnits) = false

--- a/src/types.jl
+++ b/src/types.jl
@@ -255,3 +255,31 @@ end
 MixedUnits{T}() where {T} = MixedUnits{T, typeof(NoUnits)}(NoUnits)
 MixedUnits{T}(u::Units) where {T} = MixedUnits{T,typeof(u)}(u)
 (y::MixedUnits)(x::Number) = uconvert(y,x)
+
+# For logarithmic quantities
+struct IsRootPowerRatio{S,T}
+    val::T
+end
+IsRootPowerRatio{S}(x) where {S} = IsRootPowerRatio{S, typeof(x)}(x)
+Base.show(io::IO, x::IsRootPowerRatio{S}) where {S} =
+    print(io, ifelse(S, "root-power ratio", "power ratio"), " with reference ", x.val)
+const PowerRatio{T} = IsRootPowerRatio{false,T}
+const RootPowerRatio{T} = IsRootPowerRatio{true,T}
+@inline unwrap(x::IsRootPowerRatio) = x.val
+@inline unwrap(x) = x
+
+"""
+    reflevel(x::Level{L,S})
+    reflevel(::Type{Level{L,S}})
+    reflevel(::Type{Level{L,S,T}})
+Returns the reference level, e.g.
+
+```jldoctest
+julia> reflevel(3u"dBm")
+1 mW
+```
+"""
+function reflevel end
+@inline reflevel(x::Level{L,S}) where {L,S} = unwrap(S)
+@inline reflevel(::Type{Level{L,S}}) where {L,S} = unwrap(S)
+@inline reflevel(::Type{Level{L,S,T}}) where {L,S,T} = unwrap(S)

--- a/src/units.jl
+++ b/src/units.jl
@@ -285,3 +285,15 @@ end
 Base.mul12(x::Quantity, y::Quantity) = Base.mul12(ustrip(x), ustrip(y)) .* (unit(x) * unit(y))
 Base.mul12(x::Quantity, y::Real)     = Base.mul12(ustrip(x), y) .* unit(x)
 Base.mul12(x::Real, y::Quantity)     = Base.mul12(x, ustrip(y)) .* unit(y)
+
+# The following method must not be defined before `*(a0::FreeUnits, a::FreeUnits...)`
+"""
+    upreferred(x::Dimensions)
+Return units which are preferred for dimensions `x`. If you are using the
+factory defaults, this function will return a product of powers of base SI units
+(as [`Unitful.FreeUnits`](@ref)).
+"""
+@generated function upreferred(x::Dimensions{D}) where {D}
+    u = *(FreeUnits{((Unitful.promotion[name(z)]^z.power for z in D)...,),()}())
+    :($u)
+end

--- a/src/user.jl
+++ b/src/user.jl
@@ -297,17 +297,6 @@ function preferunits(u0::Units, u::Units...)
 end
 
 """
-    upreferred(x::Dimensions)
-Return units which are preferred for dimensions `x`. If you are using the
-factory defaults, this function will return a product of powers of base SI units
-(as [`Unitful.FreeUnits`](@ref)).
-"""
-@generated function upreferred(x::Dimensions{D}) where {D}
-    u = *(FreeUnits{((Unitful.promotion[name(z)]^z.power for z in D)...,),()}())
-    :($u)
-end
-
-"""
     upreferred(x::Number)
     upreferred(x::Quantity)
 Unit-convert `x` to units which are preferred for the dimensions of `x`.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -172,6 +172,13 @@ true
 @inline dimension(x::Type{T}) where {T <: Number} = NoDims
 @inline dimension(x::Missing) = missing
 @inline dimension(x::Type{Missing}) = missing
+@inline dimension(x::IsRootPowerRatio{S,T}) where {S,T} = dimension(T)
+@inline dimension(x::Level) = dimension(reflevel(x))
+@inline dimension(x::Type{T}) where {T<:Level} = dimension(reflevel(T))
+@inline dimension(x::Gain) = NoDims
+@inline dimension(x::Type{<:Gain}) = NoDims
+
+dimension(a::MixedUnits{L}) where {L} = dimension(L) * dimension(a.units)
 
 """
     dimension(u::Units{U,D}) where {U,D}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,3 @@
-module UnitfulTests
-
 using Unitful
 using Test, LinearAlgebra, Random
 import Unitful: DimensionError, AffineError
@@ -13,7 +11,7 @@ import Unitful:
     Ra, °F, °C, K,
     rad, °,
     ms, s, minute, hr, Hz,
-    J, A, N, mol, cd, V,
+    J, A, N, mol, V,
     mW, W,
     dB, dB_rp, dB_p, dBm, dBV, dBSPL, Decibel,
     Np, Np_rp, Np_p, Neper
@@ -430,7 +428,7 @@ end
     @test isa(1s, Time)
     @test isa(1A, Current)
     @test isa(1K, Temperature)
-    @test isa(1cd, Luminosity)
+    @test isa(1u"cd", Luminosity)
     @test isa(2π*rad*1.0m, Length)
     @test isa(u"h", Action)
     @test isa(3u"dBm", Power)
@@ -1139,9 +1137,9 @@ end
 
 @testset "Display" begin
     @test string(typeof(1.0m/s)) ==
-        "Unitful.Quantity{Float64,𝐋*𝐓^-1,Unitful.FreeUnits{(m, s^-1),𝐋*𝐓^-1,nothing}}"
+        "Quantity{Float64,𝐋*𝐓^-1,FreeUnits{(m, s^-1),𝐋*𝐓^-1,nothing}}"
     @test string(typeof(m/s)) ==
-        "Unitful.FreeUnits{(m, s^-1),𝐋*𝐓^-1,nothing}"
+        "FreeUnits{(m, s^-1),𝐋*𝐓^-1,nothing}"
     @test string(dimension(1u"m/s")) == "𝐋 𝐓^-1"
     @test string(NoDims) == "NoDims"
 end
@@ -1529,6 +1527,4 @@ Base.promote_rule(::Type{Num}, ::Type{<:Real}) = Num
 @testset "Custom types" begin
     # Test that @generated functions work with Quantities + custom types (#231)
     @test uconvert(u"°C", Num(100)u"K") == Num(373.15)u"°C"
-end
-
 end


### PR DESCRIPTION
Here is an audit of the `@generated` functions in Unitful, and potential problems I saw. Not all of them were real problems.

| File           | `@generated` function                       | Potentially concerning usages |
|----------------|---------------------------------------------|-------------------------|
| types.jl       |                                             |                         |
| user.jl        | `upreferred`                                  |  `*(::Units, …)`                  |
| utils.jl       |                                             |                         |
| dimensions.jl  | `*`, `literal_pow`, `inv`, `sqrt`, `cbrt`             |     none                    |
| units.jl       | `*`, `literal_pow`, `inv`, `sqrt`, `cbrt`, `tensfactor` |  `AffineError`, `*(a0::Dimensions, a::Dimensions...)`, `NoDims`              |
| quantities.jl  | `_Quantity`, `min`, `max`                         |  `dimension`                       |
| display.jl     |                                             |                         |
| promotion.jl   |                                             |                         |
| conversion.jl  | `uconvert_affine`, `convfact`                   | each other                        |
| range.jl       |                                             |                         |
| fastmath.jl    |                                             |                         |
| logarithm.jl   |                                             |                         |
| pkgdefaults.jl |                                             |                         |

I resolved these issues by:

1) moving the method `@generated function upreferred(x::Dimensions{D}) where {D}` from `user.jl` to the end of `units.jl` so that `@generated function *(a0::FreeUnits, a::FreeUnits...)` is defined already

2) move `convfact` before `uconvert_affine` in `conversion.jl`

3) move definition of `IsRootPowerRatio` from `logarithm.jl` into `types.jl`, along with functions `unwrap` and `reflevel`, such that...

4)  all definitions of `dimension` can be defined before `quantities.jl` is included. This was causing silent incorrect results without method errors, because `dimension(::Number)` was getting called instead of `dimension(::Level)` for logarithmic quantities (an applicable method was found so no world age error was triggered).

One implication is that, at least with `—compiled-modules=no` but perhaps in general, it is unsafe for other packages to define definitions of `dimension` on new types. This sounds worse than it probably is because as far as I know no other packages build on Unitful in that way.

I also setup Travis CI to try testing both with and without compiled modules (hopefully).

@c42f 