### PR TITLE
Fix two rounding issues

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -903,6 +903,8 @@ end
         @test round(typeof(1.0mm), 1.0314m; digits=1) === 1031.4mm
         @test round(u"inch", 1.0314m) === 41.0u"inch"
         @test round(Int, u"inch", 1.0314m) === 41u"inch"
+        @test round(typeof(1m), 137cm) === 1m
+        @test round(137cm/m) === 1//1
     end
 end
 


### PR DESCRIPTION
The advice added in #249 for how to round `Quantity`s did not actually work, owing to some special treatment of rounding rational numbers in Base. This PR fixes that and one other problem I noticed. I'm pretty sure there are other problems that remain to be found because the methods available in Base for rounding are not really consistent between real numeric types (perhaps by necessity but I have given it zero thought).