### PR TITLE
Auto-register basefactors for precompiled unit extension modules

### DIFF
--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -30,7 +30,20 @@ export @logscale, @logunit, @dB, @B, @cNp, @Np
 export Level, Gain
 
 const unitmodules = Vector{Module}()
-const basefactors = Dict{Symbol,Tuple{Float64,Rational{Int}}}()
+
+function _basefactors(m::Module)
+    # A hidden symbol which will be automatically attached to any module
+    # defining units, allowing `Unitful.register()` to merge in the units from
+    # that module.
+    basefactors_name = Symbol("#Unitful_basefactors")
+    if isdefined(m, basefactors_name)
+        getproperty(m, basefactors_name)
+    else
+        m.eval(:(const $basefactors_name = Dict{Symbol,Tuple{Float64,Rational{Int}}}()))
+    end
+end
+
+const basefactors = _basefactors(Unitful)
 
 include("types.jl")
 const promotion = Dict{Symbol,Unit}()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1542,3 +1542,30 @@ Base.promote_rule(::Type{Num}, ::Type{<:Real}) = Num
     # Test that @generated functions work with Quantities + custom types (#231)
     @test uconvert(u"°C", Num(100)u"K") == Num(373.15)u"°C"
 end
+
+# Test precompiled Unitful extension modules
+load_path = mktempdir()
+load_cache_path = mktempdir()
+try
+    write(joinpath(load_path, "ExampleExtension.jl"),
+          """
+          module ExampleExtension
+          using Unitful
+
+          @unit yr "yr" JulianYear 365.25u"d" true
+
+          function __init__()
+              Unitful.register(ExampleExtension)
+          end
+          end
+          """)
+    pushfirst!(LOAD_PATH, load_path)
+    pushfirst!(DEPOT_PATH, load_cache_path)
+    @eval using ExampleExtension
+    # Delay u"yr" expansion until test time
+    @eval @test uconvert(u"d", 1u"yr") == 365.25u"d"
+finally
+    rm(load_path, recursive=true)
+    rm(load_cache_path, recursive=true)
+end
+


### PR DESCRIPTION
The other day I got bitten by trying to use `@unit` in a custom extension module, but not reading the docs properly and getting confused when things didn't work.

Here's a change which removes the need for unit extension modules to know about the existence of `basefactors`.