### PR TITLE
Make `Unitful.promote_to_derived` usable again

### DIFF
--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -312,7 +312,7 @@ function promote_to_derived()
          Unitful.promote_unit(::S, ::T) where
          {S<:VoltageFreeUnits, T<:VoltageFreeUnits} = Unitful.V
          Unitful.promote_unit(::S, ::T) where
-         {S<:ResistanceFreeUnits, T<:ResistanceFreeUnits} = Unitful.Ω
+         {S<:ElectricalResistanceFreeUnits, T<:ElectricalResistanceFreeUnits} = Unitful.Ω
          Unitful.promote_unit(::S, ::T) where
          {S<:CapacitanceFreeUnits, T<:CapacitanceFreeUnits} = Unitful.F
          Unitful.promote_unit(::S, ::T) where


### PR DESCRIPTION
fix #237

`ResistanceFreeUnits` where renamed to `ElectricalResistanceFreeUnits` without testing `Unitful.promote_to_derived()` in [this commit](https://github.com/ChristianKurz/Unitful.jl/commit/34ae482b61f12b6e4ce9e3d2b2b257626a4dd29c).