### PR TITLE
Fix display() of angular degrees to be SI compliant

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -48,6 +48,13 @@ function show(io::IO, x::Unit{N,D}) where {N,D}
     show(io, FreeUnits{(x,), D, nothing}())
 end
 
+# Space between numerical value and unit should always be included
+# except for angular degress, minutes and seconds (° ′ ″)
+# See SI 9th edition, section 5.4.3; "Formatting the value of a quantity"
+# https://www.bipm.org/utils/common/pdf/si-brochure/SI-Brochure-9.pdf
+has_unit_spacing(u) = true
+has_unit_spacing(u::Units{(Unit{:Degree, NoDims}(0, 1//1),), NoDims}) = false
+
 """
     show(io::IO, x::Quantity)
 Show a unitful quantity by calling `show` on the numeric value, appending a
@@ -56,7 +63,7 @@ space, and then calling `show` on a units object `U()`.
 function show(io::IO, x::Quantity)
     show(io,x.val)
     if !isunitless(unit(x))
-        print(io," ")
+        has_unit_spacing(unit(x)) && print(io," ")
         show(io, unit(x))
     end
     nothing
@@ -65,16 +72,9 @@ end
 function show(io::IO, mime::MIME"text/plain", x::Quantity)
     show(io, mime, x.val)
     if !isunitless(unit(x))
-        print(io," ")
+        has_unit_spacing(unit(x)) && print(io," ")
         show(io, mime, unit(x))
     end
-end
-
-function show(io::IO, x::Quantity{S, NoDims, <:Units{
-    (Unitful.Unit{:Degree, NoDims}(0, 1//1),), NoDims}}) where S
-    show(io, x.val)
-    show(io, unit(x))
-    nothing
 end
 
 function show(io::IO, x::Type{T}) where T<:Quantity

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1185,6 +1185,9 @@ Base.show(io::IO, ::MIME"text/plain", ::Foo) = print(io, "42.0")
     @test repr("text/plain", 1.0 * u"m * s * kg^-1") == "1.0 m s kg^-1"
     @test repr(Foo() * u"m * s * kg^-1") == "1 m s kg^-1"
     @test repr("text/plain", Foo() * u"m * s * kg^-1") == "42.0 m s kg^-1"
+    # Angular degree printing #253
+    @test sprint(show, 1.0°)       == "1.0°"
+    @test repr("text/plain", 1.0°) == "1.0°"
 end
 
 @testset "DimensionError message" begin


### PR DESCRIPTION
As noticed in #253, `show` and `display` are inconsistent for degrees. This cleans things up to fix that (and could be simply extended if we ever supported arc minutes or arc seconds).

Closes #253