### PR TITLE
More concise printing of some standard Range types

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -84,6 +84,20 @@ function show(io::IO, x::Type{T}) where T<:Unitlike
     invoke(show, Tuple{IO, typeof(x)}, IOContext(io, :showoperators=>true), x)
 end
 
+function show(io::IO, r::Union{StepRange{T},StepRangeLen{T}}) where T<:Quantity
+    a,s,b = first(r), step(r), last(r)
+    U = unit(a)
+    print(io, '(')
+    if ustrip(U, s) == 1
+        show(io, ustrip(U, a):ustrip(U, b))
+    else
+        show(io, ustrip(U, a):ustrip(U, s):ustrip(U, b))
+    end
+    print(io, ')')
+    has_unit_spacing(U) && print(io,' ')
+    show(io, U)
+end
+
 function show(io::IO, x::typeof(NoDims))
     print(io, "NoDims")
 end

--- a/src/display.jl
+++ b/src/display.jl
@@ -48,6 +48,13 @@ function show(io::IO, x::Unit{N,D}) where {N,D}
     show(io, FreeUnits{(x,), D, nothing}())
 end
 
+# Space between numerical value and unit should always be included
+# except for angular degress, minutes and seconds (° ′ ″)
+# See SI 9th edition, section 5.4.3; "Formatting the value of a quantity"
+# https://www.bipm.org/utils/common/pdf/si-brochure/SI-Brochure-9.pdf
+has_unit_spacing(u) = true
+has_unit_spacing(u::Units{(Unit{:Degree, NoDims}(0, 1//1),), NoDims}) = false
+
 """
     show(io::IO, x::Quantity)
 Show a unitful quantity by calling `show` on the numeric value, appending a
@@ -56,7 +63,7 @@ space, and then calling `show` on a units object `U()`.
 function show(io::IO, x::Quantity)
     show(io,x.val)
     if !isunitless(unit(x))
-        print(io," ")
+        has_unit_spacing(unit(x)) && print(io," ")
         show(io, unit(x))
     end
     nothing
@@ -65,16 +72,9 @@ end
 function show(io::IO, mime::MIME"text/plain", x::Quantity)
     show(io, mime, x.val)
     if !isunitless(unit(x))
-        print(io," ")
+        has_unit_spacing(unit(x)) && print(io," ")
         show(io, mime, unit(x))
     end
-end
-
-function show(io::IO, x::Quantity{S, NoDims, <:Units{
-    (Unitful.Unit{:Degree, NoDims}(0, 1//1),), NoDims}}) where S
-    show(io, x.val)
-    show(io, unit(x))
-    nothing
 end
 
 function show(io::IO, x::Type{T}) where T<:Quantity

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1185,6 +1185,9 @@ Base.show(io::IO, ::MIME"text/plain", ::Foo) = print(io, "42.0")
     @test repr("text/plain", 1.0 * u"m * s * kg^-1") == "1.0 m s kg^-1"
     @test repr(Foo() * u"m * s * kg^-1") == "1 m s kg^-1"
     @test repr("text/plain", Foo() * u"m * s * kg^-1") == "42.0 m s kg^-1"
+    # Angular degree printing #253
+    @test sprint(show, 1.0°)       == "1.0°"
+    @test repr("text/plain", 1.0°) == "1.0°"
 end
 
 @testset "DimensionError message" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1188,6 +1188,11 @@ Base.show(io::IO, ::MIME"text/plain", ::Foo) = print(io, "42.0")
     # Angular degree printing #253
     @test sprint(show, 1.0°)       == "1.0°"
     @test repr("text/plain", 1.0°) == "1.0°"
+
+    # Concise printing of ranges
+    @test repr((1:10)*u"kg/m^3") == "(1:10) kg m^-3"
+    @test repr((1.0:0.1:10.0)*u"kg/m^3") == "(1.0:0.1:10.0) kg m^-3"
+    @test repr((1:10)*°) == "(1:10)°"
 end
 
 @testset "DimensionError message" begin


### PR DESCRIPTION
Fixes #199 in a fairly minimal way for just the two standard range types.

Based on #253 because I thought I should probably use SI spacing and that provides a mechanism to do so simply via `has_unit_spacing`.