### PR TITLE
Clarify the behavior of `zero` on `Quantity` types…

### DIFF
--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -325,6 +325,8 @@ else
 end
 zero(x::AbstractQuantity) = Quantity(zero(x.val), unit(x))
 zero(x::AffineQuantity) = Quantity(zero(x.val), absoluteunit(x))
+zero(x::Type{<:AbstractQuantity{T}}) where {T} = throw(ArgumentError("zero($x) not defined."))
+zero(x::Type{<:AbstractQuantity{T,D}}) where {T,D} = zero(T) * upreferred(D)
 zero(x::Type{<:AbstractQuantity{T,D,U}}) where {T,D,U<:ScalarUnits} = zero(T)*U()
 zero(x::Type{<:AbstractQuantity{T,D,U}}) where {T,D,U<:AffineUnits} = zero(T)*absoluteunit(U())
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -499,6 +499,9 @@ end
         @test @inferred(zero(1m)) === 0m                # Additive identity
         @test @inferred(zero(typeof(1m))) === 0m
         @test @inferred(zero(typeof(1.0m))) === 0.0m
+        @test_throws ArgumentError zero(Quantity{Int})
+        @test zero(Quantity{Int, 𝐋}) == 0m
+        @test zero(Quantity{Int, 𝐋}) isa Quantity{Int}
         @test @inferred(π/2*u"rad" + 90u"°") ≈ π        # Dimless quantities
         @test @inferred(π/2*u"rad" - 90u"°") ≈ 0        # Dimless quantities
         @test_throws DimensionError 1+1m                # Dim mismatched
@@ -1163,6 +1166,8 @@ end
             @test size(rand(Q, 2)) == (2,)
             @test size(rand(Q, 2, 3)) == (2,3)
             @test eltype(@inferred(rand(Q, 2))) == Q
+            @test_throws ArgumentError zero([1u"m", 1u"s"])
+            @test zero(Quantity{Int,𝐋}[1u"m", 1u"mm"]) == [0, 0]u"m"
         end
     end
 end
@@ -1586,4 +1591,3 @@ finally
     rm(load_path, recursive=true)
     rm(load_cache_path, recursive=true)
 end
-


### PR DESCRIPTION
… that are not fully specified. Closes #264.

- `zero(::Type{<:AbstractQuantity{T}}) where T` should fail.
- `zero(::Type{<:AbstractQuantity{T,D}}) where {T,D}` should use `upreferred(D)`.