### PR TITLE
Fix conversions between `rpm`, `rps`, and other rotational units.

### DIFF
--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -101,8 +101,8 @@ end
 @unit hr     "hr"       Hour                  3600s         false
 @unit d      "d"        Day                   86400s        false
 @unit wk     "wk"       Week                  604800s       false
-@unit rps    "rps"      RevolutionsPerSecond  1/s           false
-@unit rpm    "rpm"      RevolutionsPerMinute  1/minute      false
+@unit rps    "rps"      RevolutionsPerSecond  2π*rad/s      false
+@unit rpm    "rpm"      RevolutionsPerMinute  2π*rad/minute false
 
 # Area
 # The hectare is used more frequently than any other power-of-ten of an are.

--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -71,8 +71,7 @@ for (_x,_y) in ((:sin,:sind), (:cos,:cosd), (:tan,:tand),
 end
 
 # SI and related units
-@unit cycle  "cycle"    Cycle       2π*rad                  false
-@unit Hz     "Hz"       Hertz       1cycle/s                true
+@unit Hz     "Hz"       Hertz       1/s                     true
 @unit N      "N"        Newton      1kg*m/s^2               true
 @unit Pa     "Pa"       Pascal      1N/m^2                  true
 @unit J      "J"        Joule       1N*m                    true
@@ -102,8 +101,8 @@ end
 @unit hr     "hr"       Hour                  3600s         false
 @unit d      "d"        Day                   86400s        false
 @unit wk     "wk"       Week                  604800s       false
-@unit rps    "rps"      RevolutionsPerSecond  1cycle/s      false
-@unit rpm    "rpm"      RevolutionsPerMinute  1cycle/minute false
+@unit rps    "rps"      RevolutionsPerSecond  2π*rad/s      false
+@unit rpm    "rpm"      RevolutionsPerMinute  2π*rad/minute false
 
 # Area
 # The hectare is used more frequently than any other power-of-ten of an are.

--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -71,7 +71,8 @@ for (_x,_y) in ((:sin,:sind), (:cos,:cosd), (:tan,:tand),
 end
 
 # SI and related units
-@unit Hz     "Hz"       Hertz       1/s                     true
+@unit cycle  "cycle"    Cycle       2π*rad                  false
+@unit Hz     "Hz"       Hertz       1cycle/s                true
 @unit N      "N"        Newton      1kg*m/s^2               true
 @unit Pa     "Pa"       Pascal      1N/m^2                  true
 @unit J      "J"        Joule       1N*m                    true
@@ -101,8 +102,8 @@ end
 @unit hr     "hr"       Hour                  3600s         false
 @unit d      "d"        Day                   86400s        false
 @unit wk     "wk"       Week                  604800s       false
-@unit rps    "rps"      RevolutionsPerSecond  2π*rad/s      false
-@unit rpm    "rpm"      RevolutionsPerMinute  2π*rad/minute false
+@unit rps    "rps"      RevolutionsPerSecond  1cycle/s      false
+@unit rpm    "rpm"      RevolutionsPerMinute  1cycle/minute false
 
 # Area
 # The hectare is used more frequently than any other power-of-ten of an are.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -170,6 +170,11 @@ end
             @test uconvert(g, 1*FixedUnits(kg)) == 1000g         # manual conversion okay
             # Issue 79:
             @test isapprox(upreferred(Unitful.ɛ0), 8.85e-12u"F/m", atol=0.01e-12u"F/m")
+            # Issue 261:
+            @test 1u"rps" == 360°/s
+            @test 1u"rps" == 2π/s
+            @test 1u"rpm" == 360°/minute
+            @test 1u"rpm" == 2π/minute
         end
     end
 end


### PR DESCRIPTION
Closes #261.