### PR TITLE
Add unit "angstrom"

### DIFF
--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -182,7 +182,7 @@ const R∞ = 10_973_731.568_160/m     # (21) Rydberg constant
 @unit ft        "ft"       Foot                 12inch                  false
 @unit yd        "yd"       Yard                 3ft                     false
 @unit mi        "mi"       Mile                 1760yd                  false
-@unit angstrom  "Å"        Angstrom             (1//10)*Unitful.nm      false
+@unit angstrom  "Å"        Angstrom             (1//10)*nm      false
 
 # Area
 @unit ac        "ac"       Acre                 (316160658//78125)*m^2  false

--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -182,6 +182,7 @@ const R∞ = 10_973_731.568_160/m     # (21) Rydberg constant
 @unit ft        "ft"       Foot                 12inch                  false
 @unit yd        "yd"       Yard                 3ft                     false
 @unit mi        "mi"       Mile                 1760yd                  false
+@unit angstrom  "Å"        Angstrom             (1//10)*Unitful.nm      false
 
 # Area
 @unit ac        "ac"       Acre                 (316160658//78125)*m^2  false


### PR DESCRIPTION
I was going to contribute to [UnitfulAtomic.jl](https://github.com/sostock/UnitfulAtomic.jl), but the [author asks me to try here first](https://github.com/sostock/UnitfulAtomic.jl/pull/4).

I did not find any abbreviation of "angstrom" as "mi" does. But requiring input `Å` as a unit is harder than just typing `angstrom`. If you have better ideas, I would like to adopt.