### PR TITLE
Handle missing |> kg

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -89,7 +89,7 @@ FreeUnits{N,D}() where {N,D} = FreeUnits{N,D,nothing}()
 FreeUnits(::Units{N,D,A}) where {N,D,A} = FreeUnits{N,D,A}()
 
 const NoUnits = FreeUnits{(), NoDims}()
-(y::FreeUnits)(x::Number) = uconvert(y,x)
+(y::FreeUnits)(x) = uconvert(y,x)
 
 """
     struct ContextUnits{N,D,P,A} <: Units{N,D,A}
@@ -106,7 +106,7 @@ end
 ContextUnits{N,D,P}() where {N,D,P} = ContextUnits{N,D,P,nothing}()
 ContextUnits(u::Units{N,D,A}) where {N,D,A} =
     ContextUnits{N,D,typeof(FreeUnits(upreferred(u))),A}()
-(y::ContextUnits)(x::Number) = uconvert(y,x)
+(y::ContextUnits)(x) = uconvert(y,x)
 
 """
     struct FixedUnits{N,D,A} <: Units{N,D,A} end
@@ -254,7 +254,7 @@ struct MixedUnits{T<:LogScaled, U<:Units}
 end
 MixedUnits{T}() where {T} = MixedUnits{T, typeof(NoUnits)}(NoUnits)
 MixedUnits{T}(u::Units) where {T} = MixedUnits{T,typeof(u)}(u)
-(y::MixedUnits)(x::Number) = uconvert(y,x)
+(y::MixedUnits)(x) = uconvert(y,x)
 
 # For logarithmic quantities
 struct IsRootPowerRatio{S,T}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -171,6 +171,7 @@ end
             @test_throws DimensionError uconvert(ContextUnits(m,mm), 1kg)
             @test_throws DimensionError uconvert(m, 1*FixedUnits(kg))
             @test uconvert(g, 1*FixedUnits(kg)) == 1000g         # manual conversion okay
+            @test (1kg, 2g, missing) .|> g === ((1000//1)g, 2g, missing)
             # Issue 79:
             @test isapprox(upreferred(Unitful.ɛ0), 8.85e-12u"F/m", atol=0.01e-12u"F/m")
             # Issue 261:


### PR DESCRIPTION
Before this PR, `vec .|> kg` would fail if it contained any `missing`