### PR TITLE
Add constructorof for Quantity, and ConstructionBase dep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ julia:
   - nightly
 notifications:
   email: false
-# matrix:
-#   allow_failures:
-#   - julia: nightly
+matrix:
+  allow_failures:
+  - julia: nightly
 # uncomment the following lines to override the default test script
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
 #  - osx    # locally test on my MacBook Pro; OS X tests take too long on Travis CI
 julia:
-  - 0.7
   - 1.0
   - 1.1
   - 1.2

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
 version = "0.17.0"
 
 [deps]
+ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,8 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-julia = "≥ 0.7.0"
+julia = "1"
+ConstructionBase = "1"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-  - julia_version: 0.7
   - julia_version: 1
   - julia_version: 1.1
   - julia_version: 1.2

--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -21,6 +21,8 @@ import LinearAlgebra: Diagonal, Bidiagonal, Tridiagonal, SymTridiagonal
 import LinearAlgebra: istril, istriu, norm
 import Random
 
+import ConstructionBase: constructorof
+
 export logunit, unit, absoluteunit, dimension, uconvert, ustrip, upreferred
 export @dimension, @derived_dimension, @refunit, @unit, @affineunit, @u_str
 export Quantity, DimensionlessQuantity, NoUnits, NoDims

--- a/src/types.jl
+++ b/src/types.jl
@@ -145,6 +145,12 @@ struct Quantity{T,D,U} <: AbstractQuantity{T,D,U}
     Quantity{T,D,U}(v::Quantity) where {T,D,U} = convert(Quantity{T,D,U}, v)
 end
 
+# Field-only constructor
+Quantity{<:Any,D,U}(val) where {D,U} = Quantity{typeof(val),D,U}(val)
+
+constructorof(::Type{Unitful.Quantity{_,D,U}}) where {_,D,U} =
+    Unitful.Quantity{T,D,U} where T
+
 """
     DimensionlessUnits{U}
 Useful for dispatching on [`Unitful.Units`](@ref) types that have no dimensions.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Unitful
-using Test, LinearAlgebra, Random
+using Test, LinearAlgebra, Random, ConstructionBase
 import Unitful: DimensionError, AffineError
 import Unitful: LogScaled, LogInfo, Level, Gain, MixedUnits, Decibel
 import Unitful: FreeUnits, ContextUnits, FixedUnits, AffineUnits, AffineQuantity
@@ -75,6 +75,7 @@ const colon = Base.:(:)
     @test ContextUnits(m, FixedUnits(mm)) === ContextUnits(m, mm)
     @test ContextUnits(m, ContextUnits(mm, mm)) === ContextUnits(m, mm)
     @test_throws DimensionError ContextUnits(m,kg)
+    @test ConstructionBase.constructorof(typeof(1.0m))(2) === 2m
 end
 
 @testset "Types" begin


### PR DESCRIPTION
This is just `constructorof` for `Quantify` at this stage, as it is definitely used already and is useful. I'm not sure `constructorof` would ever be used for other types that have fields, like `Level` of `Gain`.