### PR TITLE
Add convenience tools for converting from/to magnitudes wrt. preferred units

### DIFF
--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -31,6 +31,9 @@ export uconvertp, uconvertrp, convertr, convertrp, reflevel, linear
 export @logscale, @logunit, @dB, @B, @cNp, @Np
 export Level, Gain
 
+export quantity2magnitude, magnitude2quantity
+export assert_preferunits, assert_prefersibase
+
 const unitmodules = Vector{Module}()
 
 function _basefactors(m::Module)

--- a/src/user.jl
+++ b/src/user.jl
@@ -586,3 +586,76 @@ function basefactor end
 Returns a [`Unitful.Dimensions`](@ref) object describing the given unit `x`.
 """
 function dimension end
+
+
+
+
+"""
+    assert_preferunits(u0,u...)
+Wrapper call to preferunits with assertion that it had an effect.
+"""
+function  assert_preferunits(u0,u...)
+    Unitful.preferunits(u0,u...)
+    for u in eachindex((u0, u...))
+        @assert u==upreferred(u)
+    end
+    true
+end
+
+"""
+    assert_prefersibase()
+Ensure that preferred units are SI base units
+
+```jldoctest
+julia> using Unitful
+
+julia> assert_prefersibase()
+true
+```
+"""
+assert_prefersibase()=assert_preferunits(m,s,A,K,cd,kg,mol)
+
+
+"""
+    quantity2magnitude(unit_or_quantity)
+
+Convert  unitful quantity or unit to the the preferred unit and strip
+the numerical value (magnitude) from the result. 
+This is different from Unitful.ustrip  which just strips the magnitude from the given unit.
+This shall ensure that all magnitudes calculated are expressed consistently to the same
+set of preferrred units.
+
+Example:
+
+```jldoctest
+julia> using Unitful
+
+julia> cm=quantity2magnitude(u"cm")
+0.01
+```
+
+"""
+quantity2magnitude(::Type{T}, u) where T=ustrip(upreferred(one(T)*u))
+quantity2magnitude(u)=quantity2magnitude(Float64,u)
+
+
+
+"""
+    magnitude2quantity(unit,magnitude)
+Make unitful quantity from  magnitude value 
+
+Example:
+
+```jldoctest
+julia> using Unitful
+
+julia> cm=quantity2magnitude(u"cm")
+0.01
+
+julia> magnitude2quantity(u"mm",4*cm)
+40.0 mm
+```
+
+"""
+magnitude2quantity(unit,magnitude)=uconvert(unit,magnitude*upreferred(unit))
+


### PR DESCRIPTION
Hi,

for a pde simulation toolbox potentially using several tools not able to work  with unitful (a number of sparse matrix tools etc. - I don't see that this can be fixed in a short timeframe) I would like to see some convenience tools to support working with magnitudes only. 

ustrip is of course doing the job, but forces the user to ensure that she is consistent  as we have ustrip(1m)+ustrip(1cm)==1 ...

So my proposal is to make a shortcut of ustrip(upreferred) named quantity2magnitude 

As a consequence, we need to ensure that preferunits does what the user intended, thus assert_preferunits (IMHO it would be sufficient that preferunits returns true if it was successful) and
once we are at that, assert_prefersibase.

For the other way round we need a consistent shortcut to uconvert(upreferred), this could be magnitude2quantity. 

With this setup the user can define multipliers wrt. preferred units and work consistently with them, and go back to quantities if necessary. 

... I know, this cripples a bit the idea of the package, OTOH I really believe Unitful _is great_ and should be the go-to database for working with units. We just need some more tooling around, e.g. to handle situations like the described one. 

Jürgen

