### PR TITLE
unicode exponents for display

### DIFF
--- a/docs/src/display.md
+++ b/docs/src/display.md
@@ -1,3 +1,8 @@
+By default, exponents on units or dimensions are indicated using Unicode superscripts on
+macOS and without superscripts on other operating systems. You can set the environment
+variable `UNITFUL_FANCY_EXPONENTS` to either `true` or `false` to force using or not using
+the exponents.
+
 ```@docs
 Unitful.abbr
 Unitful.prefix

--- a/src/display.jl
+++ b/src/display.jl
@@ -154,10 +154,6 @@ end
     superscript(i::Rational)
 Prints exponents.
 """
-"""
-    superscript(i::Rational)
-Prints exponents.
-"""
 function superscript(i::Rational)
     i.den == 1 ? superscript(i.num) : string(superscript(i.num), '\u141F', superscript(i.den))
 end

--- a/src/display.jl
+++ b/src/display.jl
@@ -155,8 +155,16 @@ end
 Prints exponents.
 """
 function superscript(i::Rational)
-    i.den == 1 ? superscript(i.num) : string(superscript(i.num), '\u141F', superscript(i.den))
+    v = @eval get(ENV, "UNITFUL_FANCY_EXPONENTS", $(Sys.isapple() ? "true" : "false"))
+    t = tryparse(Bool, lowercase(v))
+    k = (t === nothing) ? false : t
+    if k
+        return i.den == 1 ? superscript(i.num) : string(superscript(i.num), '\u141F', superscript(i.den))
+    else
+        i.den == 1 ? "^" * string(i.num) : "^" * replace(string(i), "//" => "/")
+    end
 end
+
 # Taken from SIUnits.jl
 superscript(i::Integer) = map(repr(i)) do c
     c == '-' ? '\u207b' :
@@ -170,5 +178,5 @@ superscript(i::Integer) = map(repr(i)) do c
     c == '8' ? '\u2078' :
     c == '9' ? '\u2079' :
     c == '0' ? '\u2070' :
-    error("Unexpected Chatacter")
+    error("unexpected character")
 end

--- a/src/display.jl
+++ b/src/display.jl
@@ -154,6 +154,25 @@ end
     superscript(i::Rational)
 Prints exponents.
 """
+"""
+    superscript(i::Rational)
+Prints exponents.
+"""
 function superscript(i::Rational)
-    i.den == 1 ? "^" * string(i.num) : "^" * replace(string(i), "//" => "/")
+    i.den == 1 ? superscript(i.num) : string(superscript(i.num), '\u141F', superscript(i.den))
+end
+# Taken from SIUnits.jl
+superscript(i::Integer) = map(repr(i)) do c
+    c == '-' ? '\u207b' :
+    c == '1' ? '\u00b9' :
+    c == '2' ? '\u00b2' :
+    c == '3' ? '\u00b3' :
+    c == '4' ? '\u2074' :
+    c == '5' ? '\u2075' :
+    c == '6' ? '\u2076' :
+    c == '7' ? '\u2077' :
+    c == '8' ? '\u2078' :
+    c == '9' ? '\u2079' :
+    c == '0' ? '\u2070' :
+    error("Unexpected Chatacter")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1194,12 +1194,14 @@ end
 end
 
 @testset "Display" begin
-    @test string(typeof(1.0m/s)) ==
-        "Quantity{Float64,𝐋*𝐓^-1,FreeUnits{(m, s^-1),𝐋*𝐓^-1,nothing}}"
-    @test string(typeof(m/s)) ==
-        "FreeUnits{(m, s^-1),𝐋*𝐓^-1,nothing}"
-    @test string(dimension(1u"m/s")) == "𝐋 𝐓^-1"
-    @test string(NoDims) == "NoDims"
+    withenv("UNITFUL_FANCY_EXPONENTS" => false) do
+        @test string(typeof(1.0m/s)) ==
+            "Quantity{Float64,𝐋*𝐓^-1,FreeUnits{(m, s^-1),𝐋*𝐓^-1,nothing}}"
+        @test string(typeof(m/s)) ==
+            "FreeUnits{(m, s^-1),𝐋*𝐓^-1,nothing}"
+        @test string(dimension(1u"m/s")) == "𝐋 𝐓^-1"
+        @test string(NoDims) == "NoDims"
+    end
 end
 
 struct Foo <: Number end
@@ -1207,18 +1209,28 @@ Base.show(io::IO, x::Foo) = print(io, "1")
 Base.show(io::IO, ::MIME"text/plain", ::Foo) = print(io, "42.0")
 
 @testset "Show quantities" begin
-    @test repr(1.0 * u"m * s * kg^-1") == "1.0 m s kg^-1"
-    @test repr("text/plain", 1.0 * u"m * s * kg^-1") == "1.0 m s kg^-1"
-    @test repr(Foo() * u"m * s * kg^-1") == "1 m s kg^-1"
-    @test repr("text/plain", Foo() * u"m * s * kg^-1") == "42.0 m s kg^-1"
-    # Angular degree printing #253
-    @test sprint(show, 1.0°)       == "1.0°"
-    @test repr("text/plain", 1.0°) == "1.0°"
+    withenv("UNITFUL_FANCY_EXPONENTS" => false) do
+        @test repr(1.0 * u"m * s * kg^-1") == "1.0 m s kg^-1"
+        @test repr("text/plain", 1.0 * u"m * s * kg^-1") == "1.0 m s kg^-1"
+        @test repr(Foo() * u"m * s * kg^-1") == "1 m s kg^-1"
+        @test repr("text/plain", Foo() * u"m * s * kg^-1") == "42.0 m s kg^-1"
 
-    # Concise printing of ranges
-    @test repr((1:10)*u"kg/m^3") == "(1:10) kg m^-3"
-    @test repr((1.0:0.1:10.0)*u"kg/m^3") == "(1.0:0.1:10.0) kg m^-3"
-    @test repr((1:10)*°) == "(1:10)°"
+        # Angular degree printing #253
+        @test sprint(show, 1.0°)       == "1.0°"
+        @test repr("text/plain", 1.0°) == "1.0°"
+
+        # Concise printing of ranges
+        @test repr((1:10)*u"kg/m^3") == "(1:10) kg m^-3"
+        @test repr((1.0:0.1:10.0)*u"kg/m^3") == "(1.0:0.1:10.0) kg m^-3"
+        @test repr((1:10)*°) == "(1:10)°"
+    end
+    withenv("UNITFUL_FANCY_EXPONENTS" => true) do
+        @test repr(1.0 * u"m * s * kg^(-1//2)") == "1.0 m s kg⁻¹ᐟ²"
+    end
+    withenv("UNITFUL_FANCY_EXPONENTS" => nothing) do
+        @test repr(1.0 * u"m * s * kg^(-1//2)") ==
+            (Sys.isapple() ? "1.0 m s kg⁻¹ᐟ²" : "1.0 m s kg^-1/2")
+    end
 end
 
 @testset "DimensionError message" begin


### PR DESCRIPTION
Suggestion for https://github.com/PainterQubits/Unitful.jl/issues/18 to use `ᐟ` for displaying fractional dimensions.

FYI, I used SIUnits' `superscript` combined with unicode character `ᐟ` (Canadian Syllabics Final Acute `'\u141F'`), which looks like a superscript `/` for fractions.

It looks like
```julia
julia> 3u"m^4/s^(1//2)"
3 m⁴ s⁻¹ᐟ²
```
and I think/hope this is good enough?