### PR TITLE
Remove code for Julia < 1.0

### DIFF
--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -280,49 +280,41 @@ isinteger(x::DimensionlessQuantity) = isinteger(uconvert(NoUnits, x))
 _rounderr() = error("specify the type of the quantity to convert to ",
     "when rounding quantities. Example: round(typeof(1u\"m\"), 137u\"cm\").")
 
-if VERSION >= v"1"
-    # convenience methods
-    round(u::Units, q::Quantity, r::RoundingMode=RoundNearest; kwargs...) =
-        round(numtype(q), u, q, r; kwargs...)
-    round(::Type{T}, u::Units, q::Quantity, r::RoundingMode=RoundNearest;
-            kwargs...) where {T<:Number} =
-        round(Quantity{T, dimension(u), typeof(u)}, q, r; kwargs...)
+# convenience methods
+round(u::Units, q::Quantity, r::RoundingMode=RoundNearest; kwargs...) =
+    round(numtype(q), u, q, r; kwargs...)
+round(::Type{T}, u::Units, q::Quantity, r::RoundingMode=RoundNearest;
+        kwargs...) where {T<:Number} =
+    round(Quantity{T, dimension(u), typeof(u)}, q, r; kwargs...)
 
-    # workhorse methods
-    round(x::AbstractQuantity, r::RoundingMode=RoundNearest; kwargs...) =
-        _rounderr()
-    round(x::DimensionlessQuantity; kwargs...) = round(uconvert(NoUnits, x); kwargs...)
-    round(x::DimensionlessQuantity, r::RoundingMode; kwargs...) =
-        round(uconvert(NoUnits, x), r; kwargs...)
-    round(::Type{T}, x::AbstractQuantity, r=RoundingMode=RoundNearest;
-        kwargs...) where {T<:Number} = _dimerr(:round)
-    round(::Type{T}, x::DimensionlessQuantity, r::RoundingMode=RoundNearest;
-        kwargs...) where {T<:Number} = round(T, uconvert(NoUnits, x), r; kwargs...)
-    function round(::Type{T}, x::Quantity, r::RoundingMode=RoundNearest;
-            kwargs...) where {S, T <: Quantity{S}}
-        u = unit(T)
-        unitless = ustrip(uconvert(u, x))
-        return Quantity{S, dimension(T), typeof(u)}(round(float(unitless), r; kwargs...))
-    end
-
-    # that should actually be fixed in Base ↓
-    trunc(x::AbstractQuantity; kwargs...) = round(x, RoundToZero; kwargs...)
-    floor(x::AbstractQuantity; kwargs...) = round(x, RoundDown; kwargs...)
-    ceil(x::AbstractQuantity; kwargs...)  = round(x, RoundUp; kwargs...)
-    trunc(::Type{T}, x::AbstractQuantity; kwargs...) where {T<:Number} =
-        round(T, x, RoundToZero; kwargs...)
-    floor(::Type{T}, x::AbstractQuantity; kwargs...) where {T<:Number} =
-        round(T, x, RoundDown; kwargs...)
-    ceil(::Type{T}, x::AbstractQuantity; kwargs...)  where {T<:Number} =
-        round(T, x, RoundUp; kwargs...)
-else
-    for f in (:floor, :ceil, :trunc, :round)
-        @eval ($f)(x::AbstractQuantity; digits=0) = _dimerr($f)
-        @eval ($f)(x::DimensionlessQuantity; digits=0) = ($f)(uconvert(NoUnits, x); digits=digits)
-        @eval ($f)(::Type{T}, x::AbstractQuantity) where {T <: Integer} = _dimerr($f)
-        @eval ($f)(::Type{T}, x::DimensionlessQuantity) where {T <: Integer} = ($f)(T, uconvert(NoUnits, x))
-    end
+# workhorse methods
+round(x::AbstractQuantity, r::RoundingMode=RoundNearest; kwargs...) =
+    _rounderr()
+round(x::DimensionlessQuantity; kwargs...) = round(uconvert(NoUnits, x); kwargs...)
+round(x::DimensionlessQuantity, r::RoundingMode; kwargs...) =
+    round(uconvert(NoUnits, x), r; kwargs...)
+round(::Type{T}, x::AbstractQuantity, r=RoundingMode=RoundNearest;
+    kwargs...) where {T<:Number} = _dimerr(:round)
+round(::Type{T}, x::DimensionlessQuantity, r::RoundingMode=RoundNearest;
+    kwargs...) where {T<:Number} = round(T, uconvert(NoUnits, x), r; kwargs...)
+function round(::Type{T}, x::Quantity, r::RoundingMode=RoundNearest;
+        kwargs...) where {S, T <: Quantity{S}}
+    u = unit(T)
+    unitless = ustrip(uconvert(u, x))
+    return Quantity{S, dimension(T), typeof(u)}(round(float(unitless), r; kwargs...))
 end
+
+# that should actually be fixed in Base ↓
+trunc(x::AbstractQuantity; kwargs...) = round(x, RoundToZero; kwargs...)
+floor(x::AbstractQuantity; kwargs...) = round(x, RoundDown; kwargs...)
+ceil(x::AbstractQuantity; kwargs...)  = round(x, RoundUp; kwargs...)
+trunc(::Type{T}, x::AbstractQuantity; kwargs...) where {T<:Number} =
+    round(T, x, RoundToZero; kwargs...)
+floor(::Type{T}, x::AbstractQuantity; kwargs...) where {T<:Number} =
+    round(T, x, RoundDown; kwargs...)
+ceil(::Type{T}, x::AbstractQuantity; kwargs...)  where {T<:Number} =
+    round(T, x, RoundUp; kwargs...)
+
 zero(x::AbstractQuantity) = Quantity(zero(x.val), unit(x))
 zero(x::AffineQuantity) = Quantity(zero(x.val), absoluteunit(x))
 zero(x::Type{<:AbstractQuantity{T}}) where {T} = throw(ArgumentError("zero($x) not defined."))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -914,24 +914,22 @@ end
     @test ceil(Int16, 1.0314m/mm) === Int16(1032.0)
     @test trunc(Int16, -1.0314m/mm) === Int16(-1031.0)
     @test round(Int16, 1.0314m/mm) === Int16(1031.0)
-    if VERSION >= v"1"
-        @test floor(typeof(1mm), 1.0314m) === 1031mm
-        @test floor(typeof(1.0mm), 1.0314m) === 1031.0mm
-        @test floor(typeof(1.0mm), 1.0314m; digits=1) === 1031.4mm
-        @test ceil(typeof(1mm), 1.0314m) === 1032mm
-        @test ceil(typeof(1.0mm), 1.0314m) === 1032.0mm
-        @test ceil(typeof(1.0mm), 1.0314m; digits=1) === 1031.4mm
-        @test trunc(typeof(1mm), -1.0314m) === -1031mm
-        @test trunc(typeof(1.0mm), -1.0314m) === -1031.0mm
-        @test trunc(typeof(1.0mm), -1.0314m; digits=1) === -1031.4mm
-        @test round(typeof(1mm), 1.0314m) === 1031mm
-        @test round(typeof(1.0mm), 1.0314m) === 1031.0mm
-        @test round(typeof(1.0mm), 1.0314m; digits=1) === 1031.4mm
-        @test round(u"inch", 1.0314m) === 41.0u"inch"
-        @test round(Int, u"inch", 1.0314m) === 41u"inch"
-        @test round(typeof(1m), 137cm) === 1m
-        @test round(137cm/m) === 1//1
-    end
+    @test floor(typeof(1mm), 1.0314m) === 1031mm
+    @test floor(typeof(1.0mm), 1.0314m) === 1031.0mm
+    @test floor(typeof(1.0mm), 1.0314m; digits=1) === 1031.4mm
+    @test ceil(typeof(1mm), 1.0314m) === 1032mm
+    @test ceil(typeof(1.0mm), 1.0314m) === 1032.0mm
+    @test ceil(typeof(1.0mm), 1.0314m; digits=1) === 1031.4mm
+    @test trunc(typeof(1mm), -1.0314m) === -1031mm
+    @test trunc(typeof(1.0mm), -1.0314m) === -1031.0mm
+    @test trunc(typeof(1.0mm), -1.0314m; digits=1) === -1031.4mm
+    @test round(typeof(1mm), 1.0314m) === 1031mm
+    @test round(typeof(1.0mm), 1.0314m) === 1031.0mm
+    @test round(typeof(1.0mm), 1.0314m; digits=1) === 1031.4mm
+    @test round(u"inch", 1.0314m) === 41.0u"inch"
+    @test round(Int, u"inch", 1.0314m) === 41u"inch"
+    @test round(typeof(1m), 137cm) === 1m
+    @test round(137cm/m) === 1//1
 end
 
 @testset "Sgn, abs, &c." begin


### PR DESCRIPTION
Since newer Unitful versions support only Julia versions ≥ 1.0, the code for supporting older versions can be removed.