### PR TITLE
Support isone

### DIFF
--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -9,7 +9,7 @@ import Base: exp, exp10, exp2, expm1, log, log10, log1p, log2
 import Base: sin, cos, tan, cot, sec, csc, atan, cis
 
 import Base: eps, mod, rem, div, fld, cld, trunc, round, sign, signbit
-import Base: isless, isapprox, isinteger, isreal, isinf, isfinite, isnan
+import Base: isless, isapprox, isinteger, isreal, isinf, isfinite, isnan, isone
 import Base: copysign, flipsign
 import Base: prevfloat, nextfloat, maxintfloat, rat, step
 import Base: length, float, last, one, oneunit, zero, range

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -341,6 +341,7 @@ isreal(x::AbstractQuantity) = isreal(x.val)
 isfinite(x::AbstractQuantity) = isfinite(x.val)
 isinf(x::AbstractQuantity) = isinf(x.val)
 isnan(x::AbstractQuantity) = isnan(x.val)
+isone(x::AbstractQuantity) = isone(x.val)
 
 eps(x::T) where {T<:AbstractQuantity} = T(eps(x.val))
 eps(x::Type{T}) where {T<:AbstractQuantity} = eps(Unitful.numtype(T))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -644,6 +644,8 @@ end
         @test !isfinite(Inf*m)
         @test isnan(NaN*m)
         @test !isnan(1.0m)
+        @test isone(1.0m)
+        @test !isone(1.4m)
     end
     @testset "> Floating point tests" begin
         @test isapprox(1.0u"m",(1.0+eps(1.0))u"m")


### PR DESCRIPTION
Hello guys, I've implemented `isone`:
```julia
julia> isone(1.0u"m")
true

julia> isone(1.4u"m")
false
```

In latest version (Unitful@1.0.0):
```julia
julia> isone(1.0u"m")
false

julia> isone(2.0u"m")
false

julia> iszero(0.0u"m")
true

julia> iszero(1.0u"m")
false
```
`iszero` works fine (not implemented), whereas `isone` gives a weird result