### PR TITLE
Support mixed argument types to `div` and friends

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Unitful"
 uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
-version = "1.0.1"
+version = "1.1.0"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Unitful"
 uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
@@ -8,8 +8,8 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-julia = "1"
 ConstructionBase = "1"
+julia = "1"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -63,9 +63,9 @@ for f in (:div, :fld, :cld)
             ($f)(z.val,y.val)
         end
 
-        ($f)(x::Number, y::AbstractQuantity) = Quantity(($f)(x, y.val), unit(y))
+        ($f)(x::Number, y::AbstractQuantity) = ($f)(x, ustrip(y)) / unit(y)
 
-        ($f)(x::AbstractQuantity, y::Number) = Quantity(($f)(x.val, y), unit(x))
+        ($f)(x::AbstractQuantity, y::Number) = unit(x) * ($f)(ustrip(x), y)
     end
 end
 

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -56,7 +56,7 @@ end
 # ambiguity resolution
 //(x::AbstractQuantity, y::Complex) = Quantity(//(x.val, y), unit(x))
 
-for f in (:div, :fld, :cld)
+for f in (:fld, :cld)
     @eval begin
         function ($f)(x::AbstractQuantity, y::AbstractQuantity)
             z = uconvert(unit(y), x)        # TODO: use promote?
@@ -67,6 +67,19 @@ for f in (:div, :fld, :cld)
 
         ($f)(x::AbstractQuantity, y::Number) = Quantity(($f)(ustrip(x), y), unit(x) / unit(y))
     end
+end
+
+function div(x::AbstractQuantity, y::AbstractQuantity, r::RoundingMode=RoundToZero)
+    z = uconvert(unit(y), x)        # TODO: use promote?
+    div(z.val,y.val, r)
+end
+
+function div(x::Number, y::AbstractQuantity, r::RoundingMode=RoundToZero)
+    Quantity(div(x, ustrip(y), r), unit(x) / unit(y))
+end
+
+function div(x::AbstractQuantity, y::Number, r::RoundingMode=RoundToZero)
+    Quantity(div(ustrip(x), y, r), unit(x) / unit(y))
 end
 
 for f in (:mod, :rem)

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -63,9 +63,9 @@ for f in (:div, :fld, :cld)
             ($f)(z.val,y.val)
         end
 
-        ($f)(x::Number, y::AbstractQuantity) = ($f)(x, ustrip(y)) / unit(y)
+        ($f)(x::Number, y::AbstractQuantity) = Quantity(($f)(x, ustrip(y)), unit(x) / unit(y))
 
-        ($f)(x::AbstractQuantity, y::Number) = unit(x) * ($f)(ustrip(x), y)
+        ($f)(x::AbstractQuantity, y::Number) = Quantity(($f)(ustrip(x), y), unit(x) / unit(y))
     end
 end
 

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -57,9 +57,15 @@ end
 //(x::AbstractQuantity, y::Complex) = Quantity(//(x.val, y), unit(x))
 
 for f in (:div, :fld, :cld)
-    @eval function ($f)(x::AbstractQuantity, y::AbstractQuantity)
-        z = uconvert(unit(y), x)        # TODO: use promote?
-        ($f)(z.val,y.val)
+    @eval begin
+        function ($f)(x::AbstractQuantity, y::AbstractQuantity)
+            z = uconvert(unit(y), x)        # TODO: use promote?
+            ($f)(z.val,y.val)
+        end
+
+        ($f)(x::Number, y::AbstractQuantity) = Quantity(($f)(x, y.val), unit(y))
+
+        ($f)(x::AbstractQuantity, y::Number) = Quantity(($f)(x.val, y), unit(x))
     end
 end
 

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -65,7 +65,7 @@ for f in (:fld, :cld)
 
         ($f)(x::Number, y::AbstractQuantity) = Quantity(($f)(x, ustrip(y)), unit(x) / unit(y))
 
-        ($f)(x::AbstractQuantity, y::Number) = Quantity(($f)(ustrip(x), y), unit(x) / unit(y))
+        ($f)(x::AbstractQuantity, y::Number) = Quantity(($f)(ustrip(x), y), unit(x))
     end
 end
 
@@ -79,7 +79,7 @@ function div(x::Number, y::AbstractQuantity, r::RoundingMode=RoundToZero)
 end
 
 function div(x::AbstractQuantity, y::Number, r::RoundingMode=RoundToZero)
-    Quantity(div(ustrip(x), y, r), unit(x) / unit(y))
+    Quantity(div(ustrip(x), y, r), unit(x))
 end
 
 for f in (:mod, :rem)

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -69,17 +69,17 @@ for f in (:fld, :cld)
     end
 end
 
-function div(x::AbstractQuantity, y::AbstractQuantity, r::RoundingMode=RoundToZero)
+function div(x::AbstractQuantity, y::AbstractQuantity, r...)
     z = uconvert(unit(y), x)        # TODO: use promote?
-    div(z.val,y.val, r)
+    div(z.val,y.val, r...)
 end
 
-function div(x::Number, y::AbstractQuantity, r::RoundingMode=RoundToZero)
-    Quantity(div(x, ustrip(y), r), unit(x) / unit(y))
+function div(x::Number, y::AbstractQuantity, r...)
+    Quantity(div(x, ustrip(y), r...), unit(x) / unit(y))
 end
 
-function div(x::AbstractQuantity, y::Number, r::RoundingMode=RoundToZero)
-    Quantity(div(ustrip(x), y, r), unit(x))
+function div(x::AbstractQuantity, y::Number, r...)
+    Quantity(div(ustrip(x), y, r...), unit(x))
 end
 
 for f in (:mod, :rem)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -562,12 +562,12 @@ end
         @test missing / m === missing        # Missing / Unit (// is not defined for Missing)
         @test @inferred(div(10m, -3cm)) === -333
         @test @inferred(div(10m, 3)) === 3m
-        @test @inferred(div(10, 3m)) === 3m
+        @test @inferred(div(10, 3m)) === 3/m
         @test @inferred(fld(10m, -3cm)) === -334
         @test @inferred(fld(10m, 3)) === 3m
-        @test @inferred(fld(10, 3m)) === 3m
+        @test @inferred(fld(10, 3m)) === 3/m
         @test @inferred(cld(10m, 3)) === 4m
-        @test @inferred(cld(10, 3m)) === 4m
+        @test @inferred(cld(10, 3m)) === 4/m
         @test rem(10m, -3cm) == 1.0cm
         @test mod(10m, -3cm) == -2.0cm
         @test mod(1hr+3minute+5s, 24s) == 17s

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -561,7 +561,13 @@ end
         @test m / missing === missing        # Unit / missing
         @test missing / m === missing        # Missing / Unit (// is not defined for Missing)
         @test @inferred(div(10m, -3cm)) === -333
+        @test @inferred(div(10m, 3)) === 3m
+        @test @inferred(div(10, 3m)) === 3m
         @test @inferred(fld(10m, -3cm)) === -334
+        @test @inferred(fld(10m, 3)) === 3m
+        @test @inferred(fld(10, 3m)) === 3m
+        @test @inferred(cld(10m, 3)) === 4m
+        @test @inferred(cld(10, 3m)) === 4m
         @test rem(10m, -3cm) == 1.0cm
         @test mod(10m, -3cm) == -2.0cm
         @test mod(1hr+3minute+5s, 24s) == 17s


### PR DESCRIPTION
This simply makes it so that when something like `div(9m, 3)` it produces `3m`. Currently this errors instead.