### PR TITLE
Use integer for conversion if ratio is whole

### DIFF
--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -38,6 +38,10 @@ Find the conversion factor from unit `t` to unit `s`, e.g. `convfact(m,cm) = 0.0
         end
     end
 
+    if denominator(ex) == 1 # Use an integer for conversion if the ratio is whole
+        ex = numerator(ex)  # so that, e.g., uconvert(s, 1minute) = 60s
+    end
+
     a ≈ 1.0 ? (inex = 1) : (inex = a)
     y = inex * ex
     :($y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -177,7 +177,7 @@ end
             @test_throws DimensionError uconvert(ContextUnits(m,mm), 1kg)
             @test_throws DimensionError uconvert(m, 1*FixedUnits(kg))
             @test uconvert(g, 1*FixedUnits(kg)) == 1000g         # manual conversion okay
-            @test (1kg, 2g, missing) .|> g === ((1000//1)g, 2g, missing)
+            @test (1kg, 2g, 3mg, missing) .|> g === (1000g, 2g, (3//1000)g, missing)
             # Issue 79:
             @test isapprox(upreferred(Unitful.ɛ0), 8.85e-12u"F/m", atol=0.01e-12u"F/m")
             # Issue 261:
@@ -297,7 +297,7 @@ end
         @test @inferred(upreferred(unit(1g |> ContextUnits(g,mg)))) === ContextUnits(mg,mg)
         @test @inferred(upreferred(1g |> ContextUnits(g,mg))) == 1000mg
 
-        @test @inferred(upreferred(1N)) === (1//1)*kg*m/s^2
+        @test @inferred(upreferred(1N)) === 1*kg*m/s^2
         @test ismissing(upreferred(missing))
     end
     @testset "> promote_unit" begin


### PR DESCRIPTION
I find that when the conversion factor is whole, it is surprising that a rational is used instead of an integer. For example, I would expect

```julia
using Unitful: minute, s
1minute |> s
```

to give `60s` instead of the current behaviour, `(60//1)s`. 

This very simple PR remedies this by replacing whole conversion factors with their numerator. This keeps Unitful.jl's exact-conversion feature AFAIU but provides a more natural result for very simple cases like the one above.
