### PR TITLE
Add readme link to UnitfulRecipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ mathematical operations and collections that are found in Julia base.
 
 ### Feature additions
 
+- [UnitfulRecipes.jl](https://github.com/jw3126/UnitfulRecipes.jl): Adds automatic labels for [Plots.jl](https://github.com/JuliaPlots/Plots.jl).
 - [UnitfulIntegration.jl](https://github.com/PainterQubits/UnitfulIntegration.jl): Enables use of Unitful quantities with [QuadGK.jl](https://github.com/JuliaMath/QuadGK.jl). PRs for other integration packages are welcome.
 
 ## Related packages


### PR DESCRIPTION
I thought I remembered this working, and was confused by the error messages today... it turns out that plot recipes live in a different package. So perhaps having a link from the readme would be helpful?