### PR TITLE
Converting Dates.FixedPeriod to Quantity{...,𝐓}

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "1.2.0"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 

--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -17,6 +17,8 @@ import Base: getindex, eltype, step, last, first, frexp
 import Base: Integer, Rational, typemin, typemax
 import Base: steprange_last, unsigned
 
+import Dates: Dates
+
 import LinearAlgebra: Diagonal, Bidiagonal, Tridiagonal, SymTridiagonal
 import LinearAlgebra: istril, istriu, norm
 import Random
@@ -64,5 +66,6 @@ include("fastmath.jl")
 include("logarithm.jl")
 include("complex.jl")
 include("pkgdefaults.jl")
+include("dates.jl")
 
 end

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -154,14 +154,14 @@ uconvert(a::Units, x::FixedPeriod) = uconvert(a, _unit(x))
 
 convert(type::Type{<:Quantity}, x::FixedPeriod) = convert(type, _unit(x))
 
-_unit(::Nanosecond) = x.value * u"ns"
-_unit(::Microsecond) = x.value * u"μs"
-_unit(::Millisecond) = x.value * u"ms"
-_unit(::Second) = x.value * u"s"
-_unit(::Minute) = x.value * u"minute"
-_unit(::Hour) = x.value * u"hr"
-_unit(::Day) = x.value * u"d"
-_unit(::Week) = x.value * u"wk"
+_unit(x::Nanosecond) = x.value * u"ns"
+_unit(x::Microsecond) = x.value * u"μs"
+_unit(x::Millisecond) = x.value * u"ms"
+_unit(x::Second) = x.value * u"s"
+_unit(x::Minute) = x.value * u"minute"
+_unit(x::Hour) = x.value * u"hr"
+_unit(x::Day) = x.value * u"d"
+_unit(x::Week) = x.value * u"wk"
 
 Base.inv(x::FixedPeriod) = inv(_unit(x))
 

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -146,3 +146,22 @@ convert(::Type{T}, y::Quantity) where {T <: Real} =
     T(uconvert(NoUnits, y))
 convert(::Type{T}, y::Quantity) where {T <: Complex} =
     T(uconvert(NoUnits, y))
+
+using Dates: FixedPeriod
+# Dates.FixedPeriod == Union{Day, Hour, Microsecond, Millisecond, Minute, Nanosecond, Second, Week}
+
+uconvert(a::Units, x::FixedPeriod) = uconvert(a, _unit(x))
+
+convert(type::Type{<:Quantity}, x::FixedPeriod) = convert(type, _unit(x))
+
+_unit(::Nanosecond) = x.value * u"ns"
+_unit(::Microsecond) = x.value * u"μs"
+_unit(::Millisecond) = x.value * u"ms"
+_unit(::Second) = x.value * u"s"
+_unit(::Minute) = x.value * u"minute"
+_unit(::Hour) = x.value * u"hr"
+_unit(::Day) = x.value * u"d"
+_unit(::Week) = x.value * u"wk"
+
+Base.inv(x::FixedPeriod) = inv(_unit(x))
+

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -146,22 +146,3 @@ convert(::Type{T}, y::Quantity) where {T <: Real} =
     T(uconvert(NoUnits, y))
 convert(::Type{T}, y::Quantity) where {T <: Complex} =
     T(uconvert(NoUnits, y))
-
-using Dates: FixedPeriod
-# Dates.FixedPeriod == Union{Day, Hour, Microsecond, Millisecond, Minute, Nanosecond, Second, Week}
-
-uconvert(a::Units, x::FixedPeriod) = uconvert(a, _unit(x))
-
-convert(type::Type{<:Quantity}, x::FixedPeriod) = convert(type, _unit(x))
-
-_unit(x::Nanosecond) = x.value * u"ns"
-_unit(x::Microsecond) = x.value * u"μs"
-_unit(x::Millisecond) = x.value * u"ms"
-_unit(x::Second) = x.value * u"s"
-_unit(x::Minute) = x.value * u"minute"
-_unit(x::Hour) = x.value * u"hr"
-_unit(x::Day) = x.value * u"d"
-_unit(x::Week) = x.value * u"wk"
-
-Base.inv(x::FixedPeriod) = inv(_unit(x))
-

--- a/src/dates.jl
+++ b/src/dates.jl
@@ -13,7 +13,7 @@ Quantity(x::Dates.Week) = x.value * u"wk"
 uconvert(a::Units, x::Dates.FixedPeriod) = uconvert(a, Quantity(x))
 
 Base.promote_rule(::Type{Quantity{T,D,U}}, ::Type{<:Dates.FixedPeriod}) where {T,D,U} =
-    Quantity{promote_type(T,Int),D,U}
+    Quantity{promote_type(T,Int64),D,U}
 
 convert(type::Type{<:Quantity}, x::Dates.FixedPeriod) = convert(type, Quantity(x))
 

--- a/src/dates.jl
+++ b/src/dates.jl
@@ -1,0 +1,20 @@
+
+
+# Dates.FixedPeriod == Union{Day, Hour, Microsecond, Millisecond, Minute, Nanosecond, Second, Week}
+Quantity(x::Dates.Nanosecond) = x.value * u"ns"
+Quantity(x::Dates.Microsecond) = x.value * u"μs"
+Quantity(x::Dates.Millisecond) = x.value * u"ms"
+Quantity(x::Dates.Second) = x.value * u"s"
+Quantity(x::Dates.Minute) = x.value * u"minute"
+Quantity(x::Dates.Hour) = x.value * u"hr"
+Quantity(x::Dates.Day) = x.value * u"d"
+Quantity(x::Dates.Week) = x.value * u"wk"
+
+uconvert(a::Units, x::Dates.FixedPeriod) = uconvert(a, Quantity(x))
+
+Base.promote_rule(::Type{Quantity{T,D,U}}, ::Type{<:Dates.FixedPeriod}) where {T,D,U} =
+    Quantity{promote_type(T,Int),D,U}
+
+convert(type::Type{<:Quantity}, x::Dates.FixedPeriod) = convert(type, Quantity(x))
+
+Base.inv(x::Dates.FixedPeriod) = inv(Quantity(x))

--- a/src/dates.jl
+++ b/src/dates.jl
@@ -18,3 +18,12 @@ Base.promote_rule(::Type{Quantity{T,D,U}}, ::Type{<:Dates.FixedPeriod}) where {T
 convert(type::Type{<:Quantity}, x::Dates.FixedPeriod) = convert(type, Quantity(x))
 
 Base.inv(x::Dates.FixedPeriod) = inv(Quantity(x))
+
+convert(::Type{Dates.Nanosecond}, x::Quantity) = Dates.Nanosecond(ustrip(uconvert(u"ns", x)))
+convert(::Type{Dates.Microsecond}, x::Quantity) = Dates.Microsecond(ustrip(uconvert(u"μs", x)))
+convert(::Type{Dates.Millisecond}, x::Quantity) = Dates.Millisecond(ustrip(uconvert(u"ms", x)))
+convert(::Type{Dates.Second}, x::Quantity) = Dates.Second(ustrip(uconvert(u"s", x)))
+convert(::Type{Dates.Minute}, x::Quantity) = Dates.Minute(ustrip(uconvert(u"minute", x)))
+convert(::Type{Dates.Hour}, x::Quantity) = Dates.Hour(ustrip(uconvert(u"hr", x)))
+convert(::Type{Dates.Day}, x::Quantity) = Dates.Day(ustrip(uconvert(u"d", x)))
+convert(::Type{Dates.Week}, x::Quantity) = Dates.Week(ustrip(uconvert(u"wk", x)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Unitful
-using Test, LinearAlgebra, Random, ConstructionBase
+using Test, LinearAlgebra, Random, Dates, ConstructionBase
 import Unitful: DimensionError, AffineError
 import Unitful: LogScaled, LogInfo, Level, Gain, MixedUnits, Decibel
 import Unitful: FreeUnits, ContextUnits, FixedUnits, AffineUnits, AffineQuantity
@@ -186,6 +186,19 @@ end
             @test 1u"rpm" == 360°/minute
             @test 1u"rpm" == 2π/minute
         end
+    end
+    @testset "> Date ↔ unitful conversion" begin
+        uconvert(u"s", Nanosecond(1)) === (1//10^9)u"s"
+        uconvert(u"s", Microsecond(1)) === (1//10^6)u"s"
+        uconvert(u"s", Millisecond(1)) === (1//1000)u"s"
+        uconvert(u"s", Second(1)) === 1u"s"
+        uconvert(u"s", Minute(1)) === 60u"s"
+        uconvert(u"s", Hour(1)) === 3600u"s"
+        uconvert(u"hr", Day(1)) === 24u"hr"
+        uconvert(u"hr", Week(1)) === 7*24u"hr"
+
+        convert(typeof(2u"s"), Second(3)) === 3u"s"
+        promote(4u"s", Second(5)) === (4u"s", 5u"s")
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -199,6 +199,10 @@ end
 
         convert(typeof(2u"s"), Second(3)) === 3u"s"
         promote(4u"s", Second(5)) === (4u"s", 5u"s")
+
+        convert(Second, 1u"hr") === Second(3600)
+        convert(Minute, 1u"hr") === Minute(60)
+        convert(Day, 2u"wk") === Day(14)
     end
 end
 


### PR DESCRIPTION
Fixes #125, or at least makes a start. 

Edit: I moved this to a new file, as it needs to come after the relevant units have been defined. 
```julia
julia> uconvert(s, Microsecond(1))
1//1000000 s

julia> convert(typeof(1f0s), Minute(1))
60.0f0 s

julia> promote(Minute(1), 1s) 
(60 s, 1 s)
```
Should things like this be made to work?
```julia
julia> Minute(1) + 1s
ERROR: MethodError: no method matching +(::Minute, ::Quantity{Int64,𝐓,Unitful.FreeUnits{(s,)
```
