### PR TITLE
Small fixes to documentation

### DIFF
--- a/docs/src/highlights.md
+++ b/docs/src/highlights.md
@@ -29,7 +29,7 @@ julia> whatsit(1u"A" * 2.5u"Ω")
 
 It may be tempting to specify the dimensions of a quantity in a type definition, e.g.
 
-```
+```jl
 struct Person
     height::Unitful.Length
     mass::Unitful.Mass
@@ -39,7 +39,7 @@ end
 However, these are abstract types. If performance is important, it may be better
 just to pick a concrete `Quantity` type:
 
-```
+```jl
 struct Person
     height::typeof(1.0u"m")
     mass::typeof(1.0u"kg")
@@ -70,7 +70,7 @@ in toy calculations for
 [general relativity](https://en.wikipedia.org/wiki/Metric_tensor_(general_relativity))
 where some conventions yield matrices with mixed dimensions:
 
-```
+```jldoctest
 julia> Diagonal([-1.0u"c^2", 1.0, 1.0, 1.0])
 4×4 Diagonal{Unitful.Quantity{Float64,D,U}}:
  -1.0 c^2   ⋅    ⋅    ⋅

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -20,7 +20,7 @@ that are defined in Julia.
 
 ## Quick start
 
-- This package requires Julia 0.7. Older versions will not be supported.
+- This package requires Julia 1.0. Older versions will not be supported.
 - `] add Unitful`
 - `using Unitful`
 
@@ -50,7 +50,7 @@ retrieve them from Unitful in one of three ways:
 3. `using Unitful.DefaultSymbols` will bring the following symbols into the
    calling namespace:
      - Dimensions `𝐋,𝐌,𝐓,𝐈,𝚯,𝐉,𝐍` for length, mass, time, current, temperature,
-     luminosity, and amount, respectively.
+       luminosity, and amount, respectively.
      - Base and derived SI units, with SI prefixes (except for `cd`, which conflicts
        with `Base.cd`)
      - `°` (degrees)

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -65,6 +65,7 @@ Example:
 ```jldoctest
 julia> uconvert(u"hr",3602u"s")
 1801//1800 hr
+
 julia> uconvert(u"J",1.0u"N*m")
 1.0 J
 ```


### PR DESCRIPTION
This PR contains some small fixes for the documentation:
* Add syntax highlighting for two code examples, `jldoctest` for one
* Julia 0.7 → Julia 1.0
* fix indentation in bulleted list
* add empty line in a doctest