### PR TITLE
Add AbstractQuantity docstring to docs

### DIFF
--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -36,6 +36,7 @@ some subset of `Unitful.Quantity` subtypes.
 
 ### Quantities
 ```@docs
+    Unitful.AbstractQuantity{T,D,U}
     Unitful.Quantity{T,D,U}
     Unitful.DimensionlessQuantity{T,U}
 ```


### PR DESCRIPTION
There is a link to the `AbstractQuantity` docstring in the documentation (in the `Quantity` docstring), but the docstring does not appear anywhere in the documentation. This PR fixes that.