### PR TITLE
Throw error for div etc. with affine quantities

### DIFF
--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -8,7 +8,7 @@ import Base: complex, widen, reim # handled in complex.jl
 import Base: exp, exp10, exp2, expm1, log, log10, log1p, log2
 import Base: sin, cos, tan, cot, sec, csc, atan, cis
 
-import Base: eps, mod, rem, div, fld, cld, trunc, round, sign, signbit
+import Base: eps, mod, rem, div, fld, cld, divrem, trunc, round, sign, signbit
 import Base: isless, isapprox, isinteger, isreal, isinf, isfinite, isnan
 import Base: copysign, flipsign
 import Base: prevfloat, nextfloat, maxintfloat, rat, step

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -89,6 +89,27 @@ for f in (:mod, :rem)
     end
 end
 
+_affineerror(f, args...) =
+    throw(AffineError("an invalid operation was attempted with affine quantities: $f($(join(args, ", ")))"))
+
+for f in (:div, :rem, :divrem)
+    for r = (RoundNearest, RoundNearestTiesAway, RoundNearestTiesUp,
+             RoundToZero, RoundUp, RoundDown)
+        @eval begin
+            $f(x::AffineQuantity, y::AffineQuantity, ::typeof($r)) = _affineerror($f, x, y, $r)
+            $f(x::AffineQuantity, y::AbstractQuantity, ::typeof($r)) = _affineerror($f, x, y, $r)
+            $f(x::AbstractQuantity, y::AffineQuantity, ::typeof($r)) = _affineerror($f, x, y, $r)
+        end
+    end
+end
+for f = (:div, :cld, :fld, :rem, :mod, :divrem, :fldmod)
+    @eval begin
+        $f(x::AffineQuantity, y::AffineQuantity) = _affineerror($f, x, y)
+        $f(x::AffineQuantity, y::AbstractQuantity) = _affineerror($f, x, y)
+        $f(x::AbstractQuantity, y::AffineQuantity) = _affineerror($f, x, y)
+    end
+end
+
 Base.mod2pi(x::DimensionlessQuantity) = mod2pi(uconvert(NoUnits, x))
 Base.mod2pi(x::AbstractQuantity{S, NoDims, <:Units{(Unitful.Unit{:Degree, NoDims}(0, 1//1),),
     NoDims}}) where S = mod(x, 360°)

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -102,7 +102,7 @@ for f in (:div, :rem, :divrem)
         end
     end
 end
-for f = (:div, :cld, :fld, :rem, :mod, :divrem, :fldmod)
+for f = (:div, :cld, :fld, :rem, :mod)
     @eval begin
         $f(x::AffineQuantity, y::AffineQuantity) = _affineerror($f, x, y)
         $f(x::AffineQuantity, y::AbstractQuantity) = _affineerror($f, x, y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -201,6 +201,7 @@ end
         @test_throws AffineError °C*°C
         @test_throws AffineError °C*K
         @test_throws AffineError (0°C)*(0°C)
+        @test_throws AffineError (1°C)/(1°C)
         @test_throws AffineError °C^2
         let x = 2
             @test_throws AffineError °C^x
@@ -216,6 +217,27 @@ end
         @test_throws AffineError 2 * (32°F)
         @test_throws AffineError (32°F) / 2
         @test_throws AffineError 2 / (32°F)
+
+        for f = (:div, :rem, :divrem)
+            @eval begin
+                @test_throws AffineError $f(32°F, 2°F)
+                @test_throws AffineError $f(32°F, 2K)
+                @test_throws AffineError $f(32K, 2°F)
+                for r = (RoundNearest, RoundNearestTiesAway, RoundNearestTiesUp,
+                         RoundToZero, RoundUp, RoundDown)
+                    @test_throws AffineError $f(32°F, 2°F, r)
+                    @test_throws AffineError $f(32°F, 2K, r)
+                    @test_throws AffineError $f(32K, 2°F, r)
+                end
+            end
+        end
+        for f = (:cld, :fld, :mod, :fldmod)
+            @eval begin
+                @test_throws AffineError $f(32°F, 2°F)
+                @test_throws AffineError $f(32°F, 2K)
+                @test_throws AffineError $f(32K, 2°F)
+            end
+        end
 
         @test zero(100°C) === 0K
         @test zero(typeof(100°C)) === 0K

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -219,19 +219,14 @@ end
         @test_throws AffineError 2 / (32°F)
 
         for f = (:div, :rem, :divrem)
-            @eval begin
-                @test_throws AffineError $f(32°F, 2°F)
-                @test_throws AffineError $f(32°F, 2K)
-                @test_throws AffineError $f(32K, 2°F)
-                for r = (RoundNearest, RoundNearestTiesAway, RoundNearestTiesUp,
-                         RoundToZero, RoundUp, RoundDown)
-                    @test_throws AffineError $f(32°F, 2°F, r)
-                    @test_throws AffineError $f(32°F, 2K, r)
-                    @test_throws AffineError $f(32K, 2°F, r)
-                end
+            @eval for r = (RoundNearest, RoundNearestTiesAway, RoundNearestTiesUp,
+                           RoundToZero, RoundUp, RoundDown)
+                @test_throws AffineError $f(32°F, 2°F, r)
+                @test_throws AffineError $f(32°F, 2K, r)
+                @test_throws AffineError $f(32K, 2°F, r)
             end
         end
-        for f = (:cld, :fld, :mod, :fldmod)
+        for f = (:div, :cld, :fld, :rem, :mod, :divrem, :fldmod)
             @eval begin
                 @test_throws AffineError $f(32°F, 2°F)
                 @test_throws AffineError $f(32°F, 2K)


### PR DESCRIPTION
Throws an `AffineError` when calling `div`, `mod`, `rem` etc. with one or more `AffineQuantity`s.