### PR TITLE
Enable Travis on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: julia
 os:
   - linux
-#  - osx    # locally test on my MacBook Pro; OS X tests take too long on Travis CI
+  - osx
 julia:
   - 1.0
   - 1


### PR DESCRIPTION
The comment says that tests take too long on macOS, I'm a bit surprised by this, let's see how it goes