### PR TITLE
Fixes for the documentation

### DIFF
--- a/docs/src/extending.md
+++ b/docs/src/extending.md
@@ -82,7 +82,7 @@ explicitly forbid any attempt to convert to SI units.
 
 One can achieve this by defining new dimensions with the [`@dimension`](@ref) or
 [`@derived_dimension`](@ref) macros. The trick is to define dimensions that display
-suggestively like physical dimensions, like 𝐋*, 𝐓* etc., but are distinct as far
+suggestively like physical dimensions, like `𝐋*`, `𝐓*` etc., but are distinct as far
 as Julia's type system is concerned. Then, you can use [`@refunit`](@ref) to
 base units for these new dimensions without reference to SI. The result will be
 that attempted conversion between the hypothetical unit system and SI will fail
@@ -90,4 +90,4 @@ with a `DimensionError`, so be sure you provide some hints in how your
 new dimensions are displayed to avoid confusing users. It would be confusing
 to throw a `DimensionError` when attempting to convert between lengths which are
 incompatible in the sense of the previous paragraph, when both lengths display their
-dimension as 𝐋.
+dimension as `𝐋`.

--- a/docs/src/logarithm.md
+++ b/docs/src/logarithm.md
@@ -255,8 +255,8 @@ end
 mdtable(tab, latex=false, head=head, side=side)
 ```
 
-‡: `1/Hz * 3dB` could be allowed, technically, but we throw an error its unclear if a
-quantity is a root-power or power quantity:
+‡: `1/Hz * 3dB` could be allowed, technically, but we throw an error if it's unclear whether
+a quantity is a root-power or power quantity:
 
 ```jldoctest
 julia> u"1/Hz" * u"3dB"

--- a/docs/src/trouble.md
+++ b/docs/src/trouble.md
@@ -70,7 +70,7 @@ julia> π/2*u"rad"+90u"°"
 
 ## Broken display of dimension characters in the REPL
 
-On some terminals with some fonts, dimension characters such as 𝐌 are displayed as an 
+On some terminals with some fonts, dimension characters such as `𝐌` are displayed as an
 empty box. Setting a wider font spacing in your terminal settings can solve this problem.
 
 ## I have a different problem

--- a/src/units.jl
+++ b/src/units.jl
@@ -71,7 +71,7 @@ a few different methods, since we have `FreeUnits`, `ContextUnits`, and `FixedUn
 
 Collect [`Unitful.Unit`](@ref) objects from the type parameter of the
 [`Unitful.Units`](@ref) objects. For identical units including SI prefixes
-(i.e. cm ≠ m), collect powers and sort uniquely by the name of the `Unit`.
+(i.e. `cm` ≠ `m`), collect powers and sort uniquely by the name of the `Unit`.
 The unique sorting permits easy unit comparisons.
 
 Examples:

--- a/src/user.jl
+++ b/src/user.jl
@@ -228,7 +228,7 @@ end
 Not called directly by the user. Given a unit symbol and a unit's name,
 will define units for each possible SI power-of-ten prefix on that unit.
 
-Example: `@prefixed_unit_symbols m Meter 𝐋 (1.0,1)` results in nm, cm, m, km, ...
+Example: `@prefixed_unit_symbols m Meter 𝐋 (1.0,1)` results in `nm`, `cm`, `m`, `km`, ...
 all getting defined in the calling namespace.
 """
 macro prefixed_unit_symbols(symb,name,dimension,basefactor)
@@ -276,10 +276,10 @@ end
 """
     preferunits(u0::Units, u::Units...)
 This function specifies the default fallback units for promotion.
-Units provided to this function must have a pure dimension of power 1, like 𝐋 or 𝐓
-but not 𝐋/𝐓 or 𝐋^2. The function will complain if this is not the case. Additionally,
+Units provided to this function must have a pure dimension of power 1, like `𝐋` or `𝐓`
+but not `𝐋/𝐓` or `𝐋^2`. The function will complain if this is not the case. Additionally,
 the function will complain if you provide two units with the same dimension, as a
-courtesy to the user. Finally, you cannot use affine units such as °C with this function.
+courtesy to the user. Finally, you cannot use affine units such as `°C` with this function.
 
 Once [`Unitful.upreferred`](@ref) has been called or quantities have been promoted,
 this function will appear to have no effect.
@@ -479,7 +479,7 @@ different modules, then the symbol found in the most recently registered module
 will be used.
 
 Note that what goes inside must be parsable as a valid Julia expression.
-In other words, u"N m" will fail if you intended to write u"N*m".
+In other words, `u"N m"` will fail if you intended to write `u"N*m"`.
 
 Examples:
 


### PR DESCRIPTION
Some fixes for the documentation. This mostly adds backticks around some unit/dimension symbols, but also rephrases one part.