### PR TITLE
Add page headers to documentation

### DIFF
--- a/docs/src/LICENSE.md
+++ b/docs/src/LICENSE.md
@@ -1,5 +1,4 @@
-License
-=======
+# License
 
 ```@eval
 using Markdown

--- a/docs/src/conversion.md
+++ b/docs/src/conversion.md
@@ -3,6 +3,7 @@ DocTestSetup = quote
     using Unitful
 end
 ```
+# Conversion/promotion
 
 ## Converting between units
 

--- a/docs/src/display.md
+++ b/docs/src/display.md
@@ -1,3 +1,5 @@
+# How units are displayed
+
 By default, exponents on units or dimensions are indicated using Unicode superscripts on
 macOS and without superscripts on other operating systems. You can set the environment
 variable `UNITFUL_FANCY_EXPONENTS` to either `true` or `false` to force using or not using

--- a/docs/src/highlights.md
+++ b/docs/src/highlights.md
@@ -3,6 +3,7 @@ DocTestSetup = quote
     using Unitful
 end
 ```
+# Highlighted features
 
 ## Dispatch on dimensions
 

--- a/docs/src/logarithm.md
+++ b/docs/src/logarithm.md
@@ -3,6 +3,7 @@ DocTestSetup = quote
     using Unitful
 end
 ```
+# Logarithmic scales
 
 !!! note
     Logarithmic scales are new to Unitful and should be considered experimental.

--- a/docs/src/manipulations.md
+++ b/docs/src/manipulations.md
@@ -3,6 +3,7 @@ DocTestSetup = quote
     using Unitful
 end
 ```
+# Manipulating units
 
 ## Unitful string macro
 

--- a/docs/src/newunits.md
+++ b/docs/src/newunits.md
@@ -3,7 +3,6 @@ DocTestSetup = quote
     using Unitful
 end
 ```
-
 # Defining new units
 
 !!! note

--- a/docs/src/temperature.md
+++ b/docs/src/temperature.md
@@ -4,6 +4,7 @@ DocTestSetup = quote
     using Unitful:AffineError
 end
 ```
+# Temperature scales
 
 Temperatures require some care. Temperature scales like `K` and `Ra` are thermodynamic
 temperature scales, with zero on the scale corresponding to absolute zero. Unit conversions

--- a/docs/src/trouble.md
+++ b/docs/src/trouble.md
@@ -3,6 +3,8 @@ DocTestSetup = quote
     using Unitful
 end
 ```
+# Troubleshooting
+
 ## Why do unit conversions yield rational numbers sometimes?
 
 We use rational numbers in this package to permit exact conversions

--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -3,6 +3,8 @@ DocTestSetup = quote
     using Unitful
 end
 ```
+# Types
+
 ## Overview
 We define a [`Unitful.Unit{U,D}`](@ref) type to represent a unit (`U` is a symbol,
 like `:Meter`, and `D` keeps track of dimensional information).


### PR DESCRIPTION
The old `mkdocs` setup was adding page headers automatically. However, Documenter doesn’t, so one has to add them as section headers.