### PR TITLE
Remove @_doctables

### DIFF
--- a/docs/src/logarithm.md
+++ b/docs/src/logarithm.md
@@ -245,11 +245,11 @@ tab = fill("", length(head), length(head))
 for col = eachindex(head), row = 1:col
     try
         tab[row, col] = string(quantities[row] * quantities[col])
-    catch e
-        if e isa Union{ArgumentError, MethodError}
-            tab[row, col] = "†"
-        else
+    catch
+        if quantities[row] === u"1/Hz" && quantities[col] === u"3dB"
             tab[row, col] = "† ‡"
+        else
+            tab[row, col] = "†"
         end
     end
 end
@@ -340,7 +340,7 @@ tab = fill("", length(head), length(head))
 for col = eachindex(head), row = 1:col
     try
         tab[row, col] = string(quantities[row] + quantities[col])
-    catch e
+    catch
         tab[row, col] = "†"
     end
 end

--- a/src/logarithm.jl
+++ b/src/logarithm.jl
@@ -443,18 +443,4 @@ _isapprox(x::Gain{L,S,T}, y::Gain{L,S,T}; atol = Gain{L}(oneunit(T)), kwargs...)
 *(A::MixedUnits, B::AbstractArray) = broadcast(*, A, B)
 *(A::AbstractArray, B::MixedUnits) = broadcast(*, A, B)
 
-# For documentation generation...
-struct InvalidOp end
-Base.show(io::IO, ::InvalidOp) = print(io, "†")
-macro _doctables(x)
-    return esc(quote
-        sprint(show,
-        try
-            $x
-        catch
-            Unitful.InvalidOp()
-        end)
-    end)
-end
-
 Base.broadcastable(x::MixedUnits) = Ref(x)


### PR DESCRIPTION
This PR removes the `@_doctables` macro which was used with the old Documenter setup to create the tables in logarithm.md. It is now obsolete. In addition, this PR makes the generation of the multiplication table more robust (by not relying on the type of error that is thrown for invalid operations).