### PR TITLE
Fix a doctest

### DIFF
--- a/src/user.jl
+++ b/src/user.jl
@@ -494,7 +494,7 @@ julia> u"m,kg,s"
 (m, kg, s)
 
 julia> typeof(1.0u"m/s")
-Quantity{Float64,𝐋*𝐓^-1,Unitful.FreeUnits{(m, s^-1),𝐋*𝐓^-1,nothing}}
+Quantity{Float64,𝐋 𝐓^-1,Unitful.FreeUnits{(m, s^-1),𝐋 𝐓^-1,nothing}}
 
 julia> u"ħ"
 1.0545718176461565e-34 J s


### PR DESCRIPTION
This changes a doctest to match the new printing of dimensions in type parameters introduced by #322.