### PR TITLE
Fix printing of complex and logarithmic quantities

### DIFF
--- a/docs/src/display.md
+++ b/docs/src/display.md
@@ -6,10 +6,12 @@ variable `UNITFUL_FANCY_EXPONENTS` to either `true` or `false` to force using or
 the exponents.
 
 ```@docs
+Unitful.BracketStyle
 Unitful.abbr
 Unitful.prefix
 Unitful.show(::IO, ::Quantity)
 Unitful.show(::IO, ::Unitful.Unitlike)
 Unitful.showrep
+Unitful.showval
 Unitful.superscript
 ```

--- a/src/display.jl
+++ b/src/display.jl
@@ -48,6 +48,57 @@ function show(io::IO, x::Unit{N,D}) where {N,D}
     show(io, FreeUnits{(x,), D, nothing}())
 end
 
+abstract type BracketStyle end
+
+struct NoBrackets <: BracketStyle end
+print_opening_bracket(io::IO, ::NoBrackets) = nothing
+print_closing_bracket(io::IO, ::NoBrackets) = nothing
+
+struct RoundBrackets <: BracketStyle end
+print_opening_bracket(io::IO, ::RoundBrackets) = print(io, '(')
+print_closing_bracket(io::IO, ::RoundBrackets) = print(io, ')')
+
+struct SquareBrackets <: BracketStyle end
+print_opening_bracket(io::IO, ::SquareBrackets) = print(io, '[')
+print_closing_bracket(io::IO, ::SquareBrackets) = print(io, ']')
+
+print_opening_bracket(io::IO, x) = print_opening_bracket(io, BracketStyle(x))
+print_closing_bracket(io::IO, x) = print_closing_bracket(io, BracketStyle(x))
+
+"""
+    BracketStyle(x)
+    BracketStyle(typeof(x))
+
+`BracketStyle` specifies whether the numeric value of a `Quantity` is printed in brackets
+(and what kind of brackets). Three styles are defined:
+
+* `NoBrackets()`: this is the default, for example used for real numbers: `1.2 m`
+* `RoundBrackets()`: used for complex numbers: `(2.5 + 1.0im) V`
+* `SquareBrackets()`: used for [`Level`](@ref)/[`Gain`](@ref): `[3 dB] Hz^-1`
+"""
+BracketStyle(x) = BracketStyle(typeof(x))
+BracketStyle(::Type) = NoBrackets()
+BracketStyle(::Type{<:Complex}) = RoundBrackets()
+
+"""
+    showval(io::IO, x::Number, brackets::Bool=true)
+
+Show the numeric value `x` of a quantity. Depending on the type of `x`, the value may be
+enclosed in brackets (see [`BracketStyle`](@ref)). If `brackets` is set to `false`, the
+brackets are not printed.
+"""
+function showval(io::IO, x::Number, brackets::Bool=true)
+    brackets && print_opening_bracket(io, x)
+    show(io, x)
+    brackets && print_closing_bracket(io, x)
+end
+
+function showval(io::IO, mime::MIME, x::Number, brackets::Bool=true)
+    brackets && print_opening_bracket(io, x)
+    show(io, mime, x)
+    brackets && print_closing_bracket(io, x)
+end
+
 # Space between numerical value and unit should always be included
 # except for angular degress, minutes and seconds (° ′ ″)
 # See SI 9th edition, section 5.4.3; "Formatting the value of a quantity"
@@ -57,22 +108,25 @@ has_unit_spacing(u::Units{(Unit{:Degree, NoDims}(0, 1//1),), NoDims}) = false
 
 """
     show(io::IO, x::Quantity)
-Show a unitful quantity by calling `show` on the numeric value, appending a
+Show a unitful quantity by calling [`showval`](@ref) on the numeric value, appending a
 space, and then calling `show` on a units object `U()`.
 """
 function show(io::IO, x::Quantity)
-    show(io,x.val)
-    if !isunitless(unit(x))
-        has_unit_spacing(unit(x)) && print(io," ")
+    if isunitless(unit(x))
+        showval(io, x.val, false)
+    else
+        showval(io, x.val, true)
+        has_unit_spacing(unit(x)) && print(io, ' ')
         show(io, unit(x))
     end
-    nothing
 end
 
 function show(io::IO, mime::MIME"text/plain", x::Quantity)
-    show(io, mime, x.val)
-    if !isunitless(unit(x))
-        has_unit_spacing(unit(x)) && print(io," ")
+    if isunitless(unit(x))
+        showval(io, mime, x.val, false)
+    else
+        showval(io, mime, x.val, true)
+        has_unit_spacing(unit(x)) && print(io, ' ')
         show(io, mime, unit(x))
     end
 end

--- a/src/logarithm.jl
+++ b/src/logarithm.jl
@@ -312,16 +312,7 @@ function Base.show(io::IO, x::Level)
     nothing
 end
 
-function Base.show(io::IO, x::Quantity{<:Union{Level,Gain},D,U}) where {D,U}
-    print(io, "[")
-    show(io, x.val)
-    print(io, "]")
-    if !isunitless(U())
-        print(io," ")
-        show(io, U())
-    end
-    nothing
-end
+BracketStyle(::Type{<:Union{Level,Gain}}) = SquareBrackets()
 
 """
     uconvertp(u::Units, x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1254,6 +1254,10 @@ Base.show(io::IO, ::MIME"text/plain", ::Foo) = print(io, "42.0")
         @test repr(Foo() * u"m * s * kg^-1") == "1 m s kg^-1"
         @test repr("text/plain", Foo() * u"m * s * kg^-1") == "42.0 m s kg^-1"
 
+        # Complex quantities
+        @test repr((1+2im) * u"m/s") == "(1 + 2im) m s^-1"
+        @test repr("text/plain", (1+2im) * u"m/s") == "(1 + 2im) m s^-1"
+
         # Angular degree printing #253
         @test sprint(show, 1.0°)       == "1.0°"
         @test repr("text/plain", 1.0°) == "1.0°"
@@ -1563,6 +1567,10 @@ end
     end
 
     @testset "> Display" begin
+        withenv("UNITFUL_FANCY_EXPONENTS" => false) do
+            @test repr(3u"dB/Hz") == "[3 dB] Hz^-1"
+            @test repr("text/plain", 3u"dB/Hz") == "[3 dB] Hz^-1"
+        end
         @test Unitful.abbr(3u"dBm") == "dBm"
         @test Unitful.abbr(@dB 3V/1.241V) == "dB (1.241 V)"
         @test string(360°) == "360°"


### PR DESCRIPTION
Fixes #285. Fixes #342.

This adds brackets to the printing of complex and mixed logarithmic quantities:
```julia
julia> 1.2u"m"
1.2 m

julia> (2.5+1.0im)u"V"
(2.5 + 1.0im) V

julia> 3u"dB/Hz"
[3 dB] Hz^-1
```

This is accomplished by adding a new trait `BracketStyle` which specifies which kind of brackets (or no brackets) are used for a given type.