### PR TITLE
Fix tests on master (and set Unitful version number to 1.4.1)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Unitful"
 uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
-version = "1.4.0"
+version = "1.4.1"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1235,10 +1235,17 @@ end
 
 @testset "Display" begin
     withenv("UNITFUL_FANCY_EXPONENTS" => false) do
-        @test string(typeof(1.0m/s)) ==
-            "Quantity{Float64,𝐋 𝐓^-1,FreeUnits{(m, s^-1),𝐋 𝐓^-1,nothing}}"
-        @test string(typeof(m/s)) ==
-            "FreeUnits{(m, s^-1),𝐋 𝐓^-1,nothing}"
+        @static if VERSION ≥ v"1.6.0-DEV.770"
+            @test string(typeof(1.0m/s)) ==
+                "Quantity{Float64, 𝐋 𝐓^-1, FreeUnits{(m, s^-1), 𝐋 𝐓^-1, nothing}}"
+            @test string(typeof(m/s)) ==
+                "FreeUnits{(m, s^-1), 𝐋 𝐓^-1, nothing}"
+        else
+            @test string(typeof(1.0m/s)) ==
+                "Quantity{Float64,𝐋 𝐓^-1,FreeUnits{(m, s^-1),𝐋 𝐓^-1,nothing}}"
+            @test string(typeof(m/s)) ==
+                "FreeUnits{(m, s^-1),𝐋 𝐓^-1,nothing}"
+        end
         @test string(dimension(1u"m/s")) == "𝐋 𝐓^-1"
         @test string(NoDims) == "NoDims"
     end


### PR DESCRIPTION
This adapts the tests to the new type parameter printing (https://github.com/JuliaLang/julia/pull/37085) and changes the version number to a new patch release (1.4.1).