### PR TITLE
Add unitless dispatch for more trig functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Unitful"
 uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
-version = "1.4.1"
+version = "1.4.2"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Unitful"
 uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
-version = "1.4.2"
+version = "1.5.0"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -6,8 +6,8 @@ import Base: abs, abs2, angle, float, fma, muladd, inv, sqrt, cbrt
 import Base: min, max, floor, ceil, real, imag, conj
 import Base: complex, widen, reim # handled in complex.jl
 import Base: exp, exp10, exp2, expm1, log, log10, log1p, log2
-import Base: sin, cos, tan, cot, sec, csc, atan, cis
-
+import Base: sin, cos, tan, asin, acos, atan, sinh, cosh, tanh, asinh, acosh, atanh,
+             sinpi, cospi, sinc, cosc, cis
 import Base: eps, mod, rem, div, fld, cld, divrem, trunc, round, sign, signbit
 import Base: isless, isapprox, isinteger, isreal, isinf, isfinite, isnan
 import Base: copysign, flipsign

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -158,7 +158,7 @@ end
 +(x::AffineQuantity, y::AffineQuantity) = throw(AffineError(
    "an invalid operation was attempted with affine quantities: $x + $y"))
 
-# Specialize substraction of affine quantities
+# Specialize subtraction of affine quantities
 -(x::AffineQuantity, y::AffineQuantity) = -(promote(x,y)...)
 function -(x::T, y::T) where T <: AffineQuantity
     return Quantity(x.val - y.val, absoluteunit(unit(x)))
@@ -210,7 +210,8 @@ end
 sqrt(x::AbstractQuantity) = Quantity(sqrt(x.val), sqrt(unit(x)))
 cbrt(x::AbstractQuantity) = Quantity(cbrt(x.val), cbrt(unit(x)))
 
-for _y in (:sin, :cos, :tan, :cot, :sec, :csc, :cis)
+for _y in (:sin, :cos, :tan, :asin, :acos, :atan, :sinh, :cosh, :tanh, :asinh, :acosh, :atanh,
+           :sinpi, :cospi, :sinc, :cosc, :cis)
     @eval ($_y)(x::DimensionlessQuantity) = ($_y)(uconvert(NoUnits, x))
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -646,6 +646,31 @@ end
         @test @inferred(csc(90°)) == 1
         @test @inferred(sec(0°)) == 1
         @test @inferred(cot(45°)) == 1
+        @test @inferred(asin(1m/1000mm)) == 90°
+        @test @inferred(acos(-1mm/1000μm)) == π*rad
+        @test @inferred(atan(2000sqrt(3)ms/2.0s)) == 60°
+        @test @inferred(acsc(5.0Hz*0.2s)) == π/2
+        @test @inferred(asec(1m/1nm)) ≈ π/2
+        @test @inferred(acot(2sqrt(3)s/2000ms)) ≈ 30°
+
+        @test @inferred(sinh(0.0rad)) == 0.0
+        @test @inferred(sinh(1J/N/m) + cosh(1rad)) ≈ MathConstants.e
+        @test @inferred(tanh(1m/1µm)) == 1
+        @test @inferred(csch(0.0°)) == Inf
+        @test @inferred(sech(0K/Ra)) == 1
+        @test @inferred(coth(1e3m*mm^-1)) == 1
+        @test @inferred(asinh(0.0mg/kg)) == 0
+        @test @inferred(acosh(1mm/1000μm)) == 0
+        @test @inferred(atanh(0W*s/J)) == 0
+        @test @inferred(acsch(hr/yr * 0)) == Inf
+        @test @inferred(asech(1.0m/1000.0mm)) == 0
+        @test @inferred(acoth(1km/1000m)) == Inf
+
+        @test @inferred(sinpi(rad/2)) == 1
+        @test @inferred(cospi(1rad)) == -1
+        @test @inferred(sinc(1rad)) === 0
+        @test @inferred(cosc(1ft/3inch)) === 0.25
+
         @test @inferred(atan(m*sqrt(3),1m)) ≈ 60°
         @test @inferred(atan(m*sqrt(3),1.0m)) ≈ 60°
         @test @inferred(atan(m*sqrt(3),1000mm)) ≈ 60°


### PR DESCRIPTION
Dispatch on unitless quantities (like `10m/3km`) for inverse and hyperbolic trig functions. Fixes #332.