### PR TITLE
Added magnetic CGS units

### DIFF
--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -172,6 +172,9 @@ const R∞ = 10_973_731.568_160/m     # (21) Rydberg constant
 @unit Ba     "Ba"       Barye       1g/cm/s^2               true
 @unit P      "P"        Poise       1g/cm/s                 true
 @unit St     "St"       Stokes      1cm^2/s                 true
+@unit Gauss  "Gauss"    Gauss       (1//10_000)*T           true
+@unit Oe     "Oe"       Oersted     (1_000/4π)*A/m          true
+@unit Mx     "Mx"       Maxwell     (1//100_000_000)*Wb     true
 
 
 #########


### PR DESCRIPTION
In this PR, I have added the CGS units for:
Magnetic flux                                                    (Maxwell)
Magnetic flux density                                       (Gauss)
Magnetic intensity/magnetic auxiliary field     (Oersted).

The gauss has the symbol `Gs`, which is taken by the SI-unit gigaseconds. I found no abbreviation for gauss I was happy with, and landed on "Gauss" as the symbol. While inelegant, it is clear. Please suggest an improvement if you can think of one.

I have little understanding of the inner workings of Unitful.jl, so feel free to point out mistakes if you see any.