### PR TITLE
Restrict `Level`s to real quantities

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -228,7 +228,7 @@ abstract type LogScaled{L<:LogInfo} <: Number end
 const RealQuantity = Union{Real, AbstractQuantity{<:Real}}
 
 """
-    struct Level{L, S, T<:Number} <: LogScaled{L}
+    struct Level{L, S, T<:Union{Real, AbstractQuantity{<:Real}}} <: LogScaled{L}
 A logarithmic scale-based level. Details about the logarithmic scale are encoded in
 `L <: LogInfo`. `S` is a reference quantity for the level, not a type. This type has one
 field, `val::T`, and the log of the ratio `val/S` is taken. This type differs from

--- a/src/types.jl
+++ b/src/types.jl
@@ -225,6 +225,8 @@ used in promotion to put levels and gains onto a common log scale.
 """
 abstract type LogScaled{L<:LogInfo} <: Number end
 
+const RealQuantity = Union{Real, AbstractQuantity{<:Real}}
+
 """
     struct Level{L, S, T<:Number} <: LogScaled{L}
 A logarithmic scale-based level. Details about the logarithmic scale are encoded in
@@ -232,17 +234,16 @@ A logarithmic scale-based level. Details about the logarithmic scale are encoded
 field, `val::T`, and the log of the ratio `val/S` is taken. This type differs from
 [`Unitful.Gain`](@ref) in that `val` is a linear quantity.
 """
-struct Level{L, S, T<:Number} <: LogScaled{L}
+struct Level{L, S, T<:RealQuantity} <: LogScaled{L}
     val::T
     function Level{L,S,T}(x) where {L,S,T}
+        S isa ReferenceQuantity || throw(DomainError(S, "Reference quantity must be real."))
         dimension(S) != dimension(x) && throw(DimensionError(S,x))
         return new{L,S,T}(x)
     end
 end
-function Level{L,S}(val::Number) where {L,S}
-    dimension(S) != dimension(val) && throw(DimensionError(S, val))
-    return Level{L,S,typeof(val)}(val)
-end
+Level{L,S}(val::Number) where {L,S} = Level{L,S,real(typeof(val))}(val)
+Level{L,S}(val::RealQuantity) where {L,S} = Level{L,S,typeof(val)}(val)
 
 """
     struct Gain{L, S, T<:Real} <: LogScaled{L}
@@ -278,6 +279,8 @@ const PowerRatio{T} = IsRootPowerRatio{false,T}
 const RootPowerRatio{T} = IsRootPowerRatio{true,T}
 @inline unwrap(x::IsRootPowerRatio) = x.val
 @inline unwrap(x) = x
+
+const ReferenceQuantity = Union{RealQuantity, IsRootPowerRatio{S,<:RealQuantity} where S}
 
 """
     reflevel(x::Level{L,S})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1329,9 +1329,22 @@ end
             # Outer constructor
             @test Level{Decibel,1}(2) isa Level{Decibel,1,Int}
             @test_throws DimensionError Level{Decibel,1}(2V)
+            @test_throws DimensionError Level{Decibel,1V}(2)
+            @test_throws InexactError Level{Decibel,1}(1+1im)
+            @test_throws DomainError Level{Decibel,1+0im}(2)
+            @test_throws DomainError Level{Decibel,(1+0im)V}(2V)
+            @test_throws DomainError Level{Decibel,(1+1im)V}(2V)
 
             # Inner constructor
             @test Level{Decibel,1,Int}(2) === Level{Decibel,1}(2)
+            @test Level{Decibel,1,Int}(2) === Level{Decibel,1,Int}(2.0)
+            @test Level{Decibel,1,Int}(2) === Level{Decibel,1,Int}(2+0im)
+            @test_throws DimensionError Level{Decibel,1,typeof(2V)}(2V)
+            @test_throws DimensionError Level{Decibel,1V,Int}(2)
+            @test_throws TypeError Level{Decibel,1,Complex{Int}}(1+1im)
+            @test_throws TypeError Level{Decibel,1V,typeof((1+1im)V)}((1+1im)V)
+            @test_throws DomainError Level{Decibel,1+0im,Int}(2)
+            @test_throws DomainError Level{Decibel,(1+0im)V,typeof(2V)}(2V)
         end
 
         @testset ">> Gain" begin


### PR DESCRIPTION
Fixes #398. This allows only real quantities in `Level`s (for the value as well as the reference quantity).