### PR TITLE
Add link to UnitfulEquivalences.jl to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ mathematical operations and collections that are found in Julia base.
 
 - [UnitfulRecipes.jl](https://github.com/jw3126/UnitfulRecipes.jl): Adds automatic labels for [Plots.jl](https://github.com/JuliaPlots/Plots.jl).
 - [UnitfulIntegration.jl](https://github.com/PainterQubits/UnitfulIntegration.jl): Enables use of Unitful quantities with [QuadGK.jl](https://github.com/JuliaMath/QuadGK.jl). PRs for other integration packages are welcome.
+- [UnitfulEquivalences.jl](https://github.com/sostock/UnitfulEquivalences.jl): Enables conversion between equivalent quantities of different dimensions, e.g. between energy and wavelength of a photon.
 
 ## Related packages
 


### PR DESCRIPTION
I just registered the UnitfulEquivalences package. This PR adds a link to it to the README.