### PR TITLE
Add custom `==`/`isequal` methods for logarithmic quantities

### DIFF
--- a/src/logarithm.jl
+++ b/src/logarithm.jl
@@ -170,6 +170,15 @@ isrootpower_dim(y) =
 ==(x::Gain, y::Level) = ==(y,x)
 ==(x::Level, y::Gain) = false
 
+for op in (:(==), :isequal)
+    @eval Base.$op(x::Level, y::Level) = $op(x.val, y.val)
+    @eval Base.$op(x::Gain{L,S}, y::Gain{L,S}) where {L,S} = $op(x.val, y.val)
+end
+
+# A consistent `hash` method for `Gain` is impossible with the current promotion rules
+# (https://github.com/PainterQubits/Unitful.jl/issues/402), therefore we don't define one.
+Base.hash(x::Level, h::UInt) = hash(x.val, h)
+
 # Addition and subtraction
 for op in (:+, :-)
     @eval Base. $op(x::Level{L,S}, y::Level{L,S}) where {L,S} = Level{L,S}(($op)(x.val, y.val))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1441,8 +1441,34 @@ end
     end
 
     @testset "> Equality" begin
+        @testset ">> Level" begin
+            @test big(3.0)dBm == big(3.0)dBm
+            @test isequal(big(3.0)dBm, big(3.0)dBm)
+            @test_broken hash(big(3.0)dBm) == hash(big(3.0)dBm)
+
+            @test @dB(3.0V/2.0V) == @dB(3V/V)
+            @test isequal(@dB(3.0V/2.0V), @dB(3V/V))
+            @test_broken hash(@dB(3.0V/2.0V)) == hash(@dB(3V/V))
+        end
+
+        @testset ">> Gain" begin
+            @test 3dB == (3//1)dB
+            @test isequal(3dB, (3//1)dB)
+            @test_broken hash(3dB) == hash((3//1)dB)
+
+            @test big(3)dB == big(3)dB
+            @test isequal(big(3)dB, big(3)dB)
+            @test_broken hash(big(3)dB) == hash(big(3)dB)
+
+            @test 0.0dB == -0.0dB
+            @test !isequal(0.0dB, -0.0dB)
+            @test hash(0.0dB) != hash(-0.0dB)
+        end
+
         @test !(20dBm == 20dB)
         @test !(20dB == 20dBm)
+        @test !(20dBm == 20dBV)
+        @test !(20dBV == 20dBm)
     end
 
     @testset "> Addition and subtraction" begin


### PR DESCRIPTION
This adds methods for `==`/`isequal` for `Gain` and `Level`.

Before:
```julia
julia> big(3)u"dB" == big(3)u"dB"
false

julia> @dB(big(3)u"V"/1u"V") == @dB(big(3)u"V"/1u"V")
false
```

After:
```julia
julia> big(3)u"dB" == big(3)u"dB"
true

julia> @dB(big(3)u"V"/1u"V") == @dB(big(3)u"V"/1u"V")
true
```
I added a compatible `hash` method for `Level`s, but it depends on hashing for `Quantity`s, which is broken (#379). Correct hashing for `Gain` is impossible with its current promotion rules (#402), so I didn’t add a `hash` method for `Gain`s.