### PR TITLE
Add `Base.isunordered(::AbstractQuantity)`

### DIFF
--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -16,6 +16,9 @@ import Base: length, float, last, one, oneunit, zero, range
 import Base: getindex, eltype, step, last, first, frexp
 import Base: Integer, Rational, typemin, typemax
 import Base: steprange_last, unsigned
+@static if VERSION ≥ v"1.7.0-DEV.119"
+    import Base: isunordered
+end
 
 import LinearAlgebra: Diagonal, Bidiagonal, Tridiagonal, SymTridiagonal
 import LinearAlgebra: istril, istriu, norm

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -393,6 +393,9 @@ isreal(x::AbstractQuantity) = isreal(x.val)
 isfinite(x::AbstractQuantity) = isfinite(x.val)
 isinf(x::AbstractQuantity) = isinf(x.val)
 isnan(x::AbstractQuantity) = isnan(x.val)
+@static if VERSION ≥ v"1.7.0-DEV.119"
+    isunordered(x::AbstractQuantity) = isunordered(x.val)
+end
 
 eps(x::T) where {T<:AbstractQuantity} = T(eps(x.val))
 eps(x::Type{T}) where {T<:AbstractQuantity} = eps(Unitful.numtype(T))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -694,6 +694,11 @@ end
         @test !isfinite(Inf*m)
         @test isnan(NaN*m)
         @test !isnan(1.0m)
+        @static if VERSION ≥ v"1.7.0-DEV.119"
+            @test isunordered(NaN*m)
+            @test !isunordered(Inf*m)
+            @test !isunordered(1.0*m)
+        end
     end
     @testset "> Floating point tests" begin
         @test isapprox(1.0u"m",(1.0+eps(1.0))u"m")


### PR DESCRIPTION
The `isunordered` function is new in Julia 1.7, this extends the function to quantities.