### PR TITLE
Implement traits correctly

### DIFF
--- a/src/range.jl
+++ b/src/range.jl
@@ -65,9 +65,8 @@ function colon(start::A, step::B, stop::A) where A<:Quantity{<:Real} where B<:Qu
     colon(promote(start, step, stop)...)
 end
 
-OrderStyle(::Type{<:Quantity{<:Real}}) = Ordered()
-ArithmeticStyle(::Type{<:Quantity{<:AbstractFloat}}) = ArithmeticRounds()
-ArithmeticStyle(::Type{<:Quantity{<:Integer}}) = ArithmeticWraps()
+OrderStyle(::Type{<:AbstractQuantity{T}}) where T = OrderStyle(T)
+ArithmeticStyle(::Type{<:AbstractQuantity{T}}) where T = ArithmeticStyle(T)
 
 (colon(start::T, step::T, stop::T) where T <: Quantity{<:Real}) =
     _colon(OrderStyle(T), ArithmeticStyle(T), start, step, stop)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1696,10 +1696,27 @@ Base.:+(a::Num, b::Num) = Num(a.x + b.x)
 Base.:-(a::Num, b::Num) = Num(a.x - b.x)
 Base.:*(a::Num, b::Num) = Num(a.x * b.x)
 Base.promote_rule(::Type{Num}, ::Type{<:Real}) = Num
+Base.ArithmeticStyle(::Type{Num}) = Base.ArithmeticRounds()
+Base.OrderStyle(::Type{Num}) = Base.Unordered()
 
 @testset "Custom types" begin
     # Test that @generated functions work with Quantities + custom types (#231)
     @test uconvert(u"°C", Num(373.15)u"K") == Num(100)u"°C"
+end
+
+@testset "Traits" begin
+    @testset "> ArithmeticStyle" begin
+        @test Base.ArithmeticStyle(1m) === Base.ArithmeticWraps()
+        @test Base.ArithmeticStyle(1.0m) === Base.ArithmeticRounds()
+        @test Base.ArithmeticStyle((1//1)m) === Base.ArithmeticUnknown()
+        @test Base.ArithmeticStyle(Num(1)m) === Base.ArithmeticRounds()
+    end
+
+    @testset "> OrderStyle" begin
+        @test Base.OrderStyle(1m) === Base.Ordered()
+        @test Base.OrderStyle((1+1im)m) === Base.Unordered()
+        @test Base.OrderStyle(Num(1)m) === Base.Unordered()
+    end
 end
 
 # Test precompiled Unitful extension modules


### PR DESCRIPTION
The old implementation works correctly for `Quantity{T}` when `T` is a number type defined in `Base`, but not when `T` is defined elsewhere and has a custom implementation of these traits.