### PR TITLE
Promote to unit of `start` in `range(start; step, length)`

### DIFF
--- a/src/range.jl
+++ b/src/range.jl
@@ -34,16 +34,17 @@ Base._range(a::Quantity{<:AbstractFloat}, st::Quantity{<:Real}, ::Nothing, len::
     Base._range(a, float(st), nothing, len)
 function Base._range(a::Quantity{<:AbstractFloat}, st::Quantity{<:AbstractFloat}, ::Nothing, len::Integer)
     dimension(a) != dimension(st) && throw(DimensionError(a, st))
-    Base._range(promote(a, st)..., nothing, len)
+    Base._range(promote(a, uconvert(unit(a), st))..., nothing, len)
 end
 Base._range(a::Quantity, st::Real, ::Nothing, len::Integer) =
-    Base._range(promote(a, st)..., nothing, len)
+    Base._range(promote(a, uconvert(unit(a), st))..., nothing, len)
 Base._range(a::Real, st::Quantity, ::Nothing, len::Integer) =
-    Base._range(promote(a, st)..., nothing, len)
+    Base._range(promote(a, uconvert(unit(a), st))..., nothing, len)
 # the following is needed to give sane error messages when doing e.g. range(1°, 2V, 5)
-function Base._range(a::T, step, ::Nothing, len::Integer) where {T<:Quantity}
+function Base._range(a::Quantity, step, ::Nothing, len::Integer)
     dimension(a) != dimension(step) && throw(DimensionError(a,step))
-    return Base._rangestyle(OrderStyle(T), ArithmeticStyle(T), a, step, len)
+    _a, _step = promote(a, uconvert(unit(a), step))
+    return Base._rangestyle(OrderStyle(_a), ArithmeticStyle(_a), _a, _step, len)
 end
 *(r::AbstractRange, y::Units) = range(first(r)*y, step=step(r)*y, length=length(r))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1070,8 +1070,11 @@ end
             @test @inferred(length(r)) === 5
             @test @inferred(step(r)) === 1m
             @test @inferred(first(range(1mm, step=2m, length=4))) === 1mm
-            @test @inferred(step(range(1mm, step=2m, length=4))) === 2m
+            @test @inferred(step(range(1mm, step=2m, length=4))) === 2000mm
             @test @inferred(last(range(1mm, step=2m, length=4))) === 6001mm
+            @test @inferred(first(range(1m, step=2mm, length=4))) === (1//1)m
+            @test @inferred(step(range(1m, step=2mm, length=4))) === (1//500)m
+            @test @inferred(last(range(1m, step=2mm, length=4))) === (503//500)m
             @test_throws DimensionError(1m, 2V) range(1m, step=2V, length=5)
             @test_throws ArgumentError 1m:0m:5m
         end
@@ -1087,6 +1090,12 @@ end
             @test @inferred(last(range(0, step=10°, length=37))) == 2pi
             @test @inferred(last(range(0°, step=2pi/36, length=37))) == 2pi
             @test step(range(1.0m, step=1m, length=5)) === 1.0m
+            @test @inferred(first(range(1.0mm, step=2.0m, length=4))) === 1.0mm
+            @test @inferred(step(range(1.0mm, step=2.0m, length=4))) === 2000.0mm
+            @test @inferred(last(range(1.0mm, step=2.0m, length=4))) === 6001.0mm
+            @test @inferred(first(range(1.0m, step=2.0mm, length=4))) === 1.0m
+            @test @inferred(step(range(1.0m, step=2.0mm, length=4))) === 0.002m
+            @test @inferred(last(range(1.0m, step=2.0mm, length=4))) === 1.006m
             @test_throws DimensionError range(1.0m, step=1.0V, length=5)
             @test_throws ArgumentError 1.0m:0.0m:5.0m
             @test (-2.0Hz:1.0Hz:2.0Hz)/1.0Hz == -2.0:1.0:2.0  # issue 160


### PR DESCRIPTION
Fixes #410.

This also fixes the tests on Julia master and makes the units consistent between different numeric types, see below.

Before:
```julia
julia> range(1mm, step=2m, length=4)
(1:2000:6001) mm

julia> range(1.0mm, step=2.0m, length=4)
(0.001:2.0:6.001) m
```

After:
```julia
julia> range(1mm, step=2m, length=4)
(1:2000:6001) mm

julia> range(1.0mm, step=2.0m, length=4)
(1.0:2000.0:6001.0) mm
```