### PR TITLE
WIP: Add DifferenceQuantities

### DIFF
--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -283,6 +283,9 @@ baremodule DefaultSymbols
     Core.eval(DefaultSymbols, Expr(:import, Expr(:(.), :Unitful, :°C)))
     Core.eval(DefaultSymbols, Expr(:export, :°C))
 
+    Core.eval(DefaultSymbols, Expr(:import, Expr(:(.), :Unitful, :Δ°C)))
+    Core.eval(DefaultSymbols, Expr(:export, :Δ°C))
+
     Core.eval(DefaultSymbols, Expr(:import, Expr(:(.), :Unitful, :°)))
     Core.eval(DefaultSymbols, Expr(:export, :°))
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -59,6 +59,7 @@ Returns a [`Unitful.Dimensions`](@ref) object describing the given unit `x`.
 @inline dimension(u::Unit{U,D}) where {U,D} = D^u.power
 
 struct Affine{T} end
+struct Difference{T}; end
 
 """
     abstract type Units{N,D,A} <: Unitlike end
@@ -175,6 +176,13 @@ under unit conversion, like absolute temperatures. Not exported.
 const AffineUnits{N,D,A} = Units{N,D,A} where A<:Affine
 
 """
+    AffineUnits{N,D,A} = Units{N,D,DD} where DD<:Difference
+Useful for dispatching on unit objects that indicate a quantity behave as a
+difference between quantities of the absolute base unit.
+"""
+const DifferenceUnit{N,D,A} = Units{N,D,DD} where DD<:Difference
+
+"""
     ScalarUnits{N,D} = Units{N,D,nothing}
 Useful for dispatching on unit objects that indicate a quantity should transform in the
 usual scalar way under unit conversion. Not exported.
@@ -201,6 +209,13 @@ Useful for dispatching on quantities that affine-transform under unit conversion
 absolute temperatures. Not exported.
 """
 const AffineQuantity{T,D,U} = AbstractQuantity{T,D,U} where U<:AffineUnits
+
+"""
+    AffineQuantity{T,D,U} = AbstractQuantity{T,D,U} where U<:AffineUnits
+Useful for dispatching on quantities that affine-transform under unit conversion, like
+absolute temperatures. Not exported.
+"""
+const DifferenceQuantity{T,D,U} = AbstractQuantity{T,D,U} where U<:DifferenceUnit
 
 """
     ScalarQuantity{T,D,U} = AbstractQuantity{T,D,U} where U<:ScalarUnits

--- a/src/user.jl
+++ b/src/user.jl
@@ -203,9 +203,13 @@ in terms of an absolute scale; the scaling is the same as the absolute scale. Ex
 """
 macro affineunit(symb, abbr, offset)
     s = Symbol(symb)
+    d = Symbol(string("Δ", symb))
+    dabbr = string("Δ", abbr)
     return esc(quote
         const global $s = $affineunit($offset)
+        const global $d = $differenceunit($s)
         $Base.show(io::$IO, ::$genericunit($s)) = $print(io, $abbr)
+        $Base.show(io::$IO, ::$genericunit($d)) = $print(io, $dabbr)
     end)
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -150,6 +150,13 @@ absoluteunit(::FreeUnits{N,D,A}) where {N,D,A} = FreeUnits{N,D}()
 absoluteunit(::ContextUnits{N,D,P,A}) where {N,D,P,A} = ContextUnits{N,D,P}()
 absoluteunit(::FixedUnits{N,D,A}) where {N,D,A} = FixedUnits{N,D}()
 
+function differenceunit end
+differenceunit(x::Quantity{T, D, U} where {T,D}) where U = differenceunit(U())
+differenceunit(::FreeUnits{N,D,A}) where {N,D,A} = FreeUnits{N,D,Difference{A}}()
+differenceunit(::ContextUnits{N,D,P,A}) where {N,D,P,A} = ContextUnits{N,D,P,Difference{A}}()
+differenceunit(::FixedUnits{N,D,A}) where {N,D,A} = FixedUnits{N,D,Difference{A}}()
+
+
 """
     dimension(x::Number)
     dimension(x::Type{T}) where {T<:Number}


### PR DESCRIPTION
These quantities represent differences between units.
At the moment, this is restricted to affine units, since
that is where this makes the most sense. However, in theory
this kind of thing could be used where-ever the scale is
non-absolute (e.g. angle differences) - though perhaps that
is best done by a AffineUnit with no offset for a particular
application.

This is by no means done, but I figured I'd put it up for
a discussion. I'm planning to play with this a bit and see
if I like it or not.

Demo:
```
julia> 1°C + 1Δ°C
2 °C

julia> 1°C + 1°C
ERROR: AffineError: an invalid operation was attempted with affine quantities: 1 °C + 1 °C
Stacktrace:
 [1] +(x::Quantity{Int64, 𝚯, Unitful.FreeUnits{(K,), 𝚯, Unitful.Affine{-5463//20}}}, y::Quantity{Int64, 𝚯, Unitful.FreeUnits{(K,), 𝚯, Unitful.Affine{-5463//20}}})
   @ Unitful ~/.julia/dev/Unitful/src/quantities.jl:184
 [2] top-level scope
   @ REPL[5]:1

julia> 5°C - 2°C
3 Δ°C
```