### PR TITLE
Remove bad at-eval

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -202,7 +202,7 @@ end
 Prints exponents.
 """
 function superscript(i::Rational)
-    v = @eval get(ENV, "UNITFUL_FANCY_EXPONENTS", $(Sys.isapple() ? "true" : "false"))
+    v = get(ENV, "UNITFUL_FANCY_EXPONENTS", Sys.isapple() ? "true" : "false")
     t = tryparse(Bool, lowercase(v))
     k = (t === nothing) ? false : t
     if k


### PR DESCRIPTION
I don't know what this was supposed to do, but what it accomplishes in reality is to break pre-compilation,
so better remove it ;).