### PR TITLE
Implement bit and byte for information and data

### DIFF
--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -224,15 +224,14 @@ const Å = Å = angstrom
 # Instead define all units in common use
 # Overflow warning:
 #  Gigascale and above likely exceed Int32
-#  Exascale and above likely exceed Int64
-@unit      kB   "kB"     KiloByte          8_000b      false
-@unit      MB   "MB"     MegaByte          8_000_000b     false
-@unit      GB   "GB"     GigaByte          8_000_000_000b     false
-@unit      TB   "TB"     TeraByte          8_000_000_000_000b    false
-@unit      PB   "PB"     PetaByte          8_000_000_000_000_000b    false
-@unit      EB   "EB"     ExaByte           8_000_000_000_000_000_000b    false
-@unit      ZB   "ZB"     ZettaByte         8_000_000_000_000_000_000_000b    false
-@unit      YB   "YB"     YottaByte         8_000_000_000_000_000_000_000_000b    false
+#  Exascale likely exceeds Int64
+# Omitting ZB and YB: Julia interprets literal as Float64, which causes rounding errors
+@unit      kB   "kB"       KiloByte          8_000b      false
+@unit      MB   "MB"       MegaByte          8_000_000b     false
+@unit      GB   "GB"       GigaByte          8_000_000_000b     false
+@unit      TB   "TB"       TeraByte          8_000_000_000_000b    false
+@unit      PB   "PB"       PetaByte          8_000_000_000_000_000b    false
+@unit      EB   "EB"       ExaByte           8_000_000_000_000_000_000b    false
 # Data rate
 @unit      bps  "bps"      BitPerSecond      1b/s         true
 @unit      Bps  "Bps"      BytePerSecond     8b/s         true

--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -9,6 +9,7 @@
 @dimension 𝚯 "𝚯" Temperature    # This one is \bfTheta
 @dimension 𝐉 "𝐉" Luminosity
 @dimension 𝐍 "𝐍" Amount
+@dimension 𝐛 "𝐛" Information
 const RelativeScaleTemperature = Quantity{T, 𝚯, <:AffineUnits} where T
 const AbsoluteScaleTemperature = Quantity{T, 𝚯, <:ScalarUnits} where T
 
@@ -60,6 +61,7 @@ const AbsoluteScaleTemperature = Quantity{T, 𝚯, <:ScalarUnits} where T
 @refunit  cd      "cd"     Candela   𝐉            true
 @refunit  g       "g"      Gram      𝐌           true
 @refunit  mol     "mol"    Mole      𝐍           true
+@refunit  b       "b"      Bit       𝐛           false
 
 # Angles and solid angles
 @unit sr      "sr"      Steradian   1                       true
@@ -113,7 +115,7 @@ end
 # The hectare is used more frequently than any other power-of-ten of an are.
 @unit a      "a"        Are         100m^2                  false
 const ha = Unitful.FreeUnits{(Unitful.Unit{:Are, 𝐋^2}(2, 1//1),), 𝐋^2}()
-@unit b      "b"        Barn        100fm^2                 true
+@unit bn     "bn"       Barn        100fm^2                 true
 
 # Volume
 # `l` is also an acceptable symbol for liters
@@ -216,11 +218,30 @@ const Å = Å = angstrom
 # Pressure
 @unit psi       "psi"      PoundsPerSquareInch  1lbf/inch^2             false
 
+# Data
+@unit      B    "B"        Byte              8b          false
+# deciBytes can be a problem with deciBels, and we don't actually care about orders < 1
+# Instead define all units in common use
+# Overflow warning:
+#  Gigascale and above likely exceed Int32
+#  Exascale and above likely exceed Int64
+@unit      kB   "kB"     KiloByte          8_000b      false
+@unit      MB   "MB"     MegaByte          8_000_000b     false
+@unit      GB   "GB"     GigaByte          8_000_000_000b     false
+@unit      TB   "TB"     TeraByte          8_000_000_000_000b    false
+@unit      PB   "PB"     PetaByte          8_000_000_000_000_000b    false
+@unit      EB   "EB"     ExaByte           8_000_000_000_000_000_000b    false
+@unit      ZB   "ZB"     ZettaByte         8_000_000_000_000_000_000_000b    false
+@unit      YB   "YB"     YottaByte         8_000_000_000_000_000_000_000_000b    false
+# Data rate
+@unit      bps  "bps"      BitPerSecond      1b/s         true
+@unit      Bps  "Bps"      BytePerSecond     8b/s         true
+
 #########
 # Logarithmic scales and units
 
 @logscale dB    "dB"       Decibel      10      10      false
-@logscale B     "B"        Bel          10      1       false
+@logscale bel   "Bel"      Bel          10      1       false
 @logscale Np    "Np"       Neper        ℯ       1//2    true
 @logscale cNp   "cNp"      Centineper   ℯ       50      true
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ import Unitful:
     ms, s, minute, hr, d, yr, Hz,
     J, A, N, mol, V,
     mW, W,
+    B, kB, MB, GB, TB, PB, EB,
     dB, dB_rp, dB_p, dBm, dBV, dBSPL, Decibel,
     Np, Np_rp, Np_p, Neper
 
@@ -298,6 +299,16 @@ end
             @test @inferred(eltype([1cc, 1°C])) <: Quantity{Rational{Int}, 𝚯, typeof(cc)}
         end
     end
+end
+
+@testset "Data prefixes" begin
+    # Ensure manually setting the SI prefixes was consistent
+    @test 1kB/B  == 1_000
+    @test 1MB/kB == 1_000
+    @test 1GB/MB == 1_000
+    @test 1TB/GB == 1_000
+    @test 1PB/TB == 1_000
+    @test 1EB/PB == 1_000
 end
 
 @testset "Promotion" begin


### PR DESCRIPTION
Create information. Define Byte as basic unit for data storage. Include data rates. Modify barn (b -> bn) and Bel (B -> bel) to accommodate the new definitions.

Closes #173.
Mostly addresses #330.
Does not include e.g. methods for converting between bits and entropy, this is probably reasonable since most users will think of bits as data (e.g. storage capacity, transfer rates) rather than information. 

Personal preferences:
- I don't think this belongs in a separate units package because bit and byte are common and conflict with the existing definitions of barn and Bel.
- Less common units are not included: nibble, 1024 multiples (kibibytes, mebibytes, etc.). A user could easily implement these.
- Baud not defined because bits per symbol is not standardized.

Quirks:
- I had to manually implement the SI prefixes for Bytes to avoid deci-bytes (dB), which is a meaningless unit and a conflict with Decibel.
- ZettaByte and YottaByte were not included because the literal 8_000_000_000_000_000_000_000 undergoes type promotion to Float64 and causes a rounding error.
    - It might be possible to implement this using Int128(8_000_000_000_000_000_000_000)
    - If there were a way to use the Unitful prefix system excluding deciByte, Unitful handles these types greacefully (e.g. `1Zm/Em == 1000` returns `true`)
    - Behavior with the 32-bit Julia binary needs review, to ensure no units promote to Float32

I've included tests for the manual SI prefixes.