### PR TITLE
Add cycles per second to units

### DIFF
--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -64,6 +64,7 @@ const AbsoluteScaleTemperature = Quantity{T, 𝚯, <:ScalarUnits} where T
 # Angles and solid angles
 @unit sr      "sr"      Steradian   1                       true
 @unit rad     "rad"     Radian      1                       true
+@unit cyc     "cyc"     Cycle       2π*rad                  true
 @unit °       "°"       Degree      pi/180                  false
 # For numerical accuracy, specific to the degree
 import Base: sind, cosd, tand, secd, cscd, cotd
@@ -108,6 +109,7 @@ end
 @unit yr     "yr"       Year                  31557600s     true
 @unit rps    "rps"      RevolutionsPerSecond  2π*rad/s      false
 @unit rpm    "rpm"      RevolutionsPerMinute  2π*rad/minute false
+@unit cps    "cps"      CyclesPerSecond       1cyc/s        true
 
 # Area
 # The hectare is used more frequently than any other power-of-ten of an are.


### PR DESCRIPTION
Cycles per second is a really powerful unit to include. In theory the definition of "Hertz" as a unit is the same as cycles per second, but in practice it is sometimes not.

In my field (electronics) cycles per second can simplify most of my calculations:
- 1 cycle = 2π radians

For example, calculating impedance of an inductor, cycles per second avoids an arbitrary factor of 2π in my equations.

With Hertz:
```jl
using Unitful: nH, Ω, MHz
L = 200nH  # Inductance
f = 10MHz  # Frequency
ω = 2π*f  # Angular frequency
Z = uconvert(Ω, im*ω*L)
```
#### ω is 62.8e6/s which is required for calculations but illegible to humans

With cycles per second:
```jl
using Unitful: nH, Ω, Mcps
L = 200nH  # Inductance
ω = 10Mcps  # Angular frequency
Z = uconvert(Ω, im*ω*L)
```
#### ω is 10e6 cyc/s, which is legible to humans and converts to the correct value in Ohms
----
### _So why not make the unit of Hertz equal to cycles per second?_ 
In electromagnetics (and probably other domains) there's a problem: it's standard to use wavelength (units: meters) instead of angular wavelength (units: meters/cycle). 
As an example, [CB radio operates around the 11 meter band](https://en.wikipedia.org/wiki/CB_radio_in_the_United_States#North_American/CEPT_frequencies), which corresponds to a frequency around 25 MHz. The conversion from wavelength to frequency requires frequency to be in units of "per second":
```jl
julia> using Unitful: m, c0, MHz, Mcps

julia> λ = 11m;  # CB radio wavelength

julia> @show ω = uconvert(Mcps, c0/λ);  # Not conventional
ω = uconvert(Mcps, c0 / λ) = 4.33758650839722 Mcps

julia> @show f = uconvert(MHz, c0/λ);  # Conventional units
f = uconvert(MHz, c0 / λ) = 27.253859818181816 MHz
```
----
Similarly you may want to consider creating the "Revolution" unit for the RPM and RPS units: 
```jl
@unit rev     "rev"     Revolution       2π*rad                  false
```