### PR TITLE
get `upreferred` to work with `AbstractQuantity`

### DIFF
--- a/src/user.jl
+++ b/src/user.jl
@@ -326,7 +326,7 @@ product of powers of base SI units. If quantity `x` has
 units `ContextUnits(z,z)`.
 """
 @inline upreferred(x::Number) = x
-@inline upreferred(x::Quantity) = uconvert(upreferred(unit(x)), x)
+@inline upreferred(x::AbstractQuantity) = uconvert(upreferred(unit(x)), x)
 @inline upreferred(::Missing) = missing
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,8 +1,8 @@
 @inline isunitless(::Units) = false
 @inline isunitless(::Units{()}) = true
 
-@inline numtype(::Quantity{T}) where {T} = T
-@inline numtype(::Type{Q}) where {T, Q<:Quantity{T}} = T
+@inline numtype(::AbstractQuantity{T}) where {T} = T
+@inline numtype(::Type{Q}) where {T, Q<:AbstractQuantity{T}} = T
 
 @inline dimtype(u::Unit{U,D}) where {U,D} = D
 
@@ -106,8 +106,8 @@ julia> unit(typeof(1.0u"m")) == u"m"
 true
 ```
 """
-@inline unit(x::Quantity{T,D,U}) where {T,D,U} = U()
-@inline unit(::Type{Quantity{T,D,U}}) where {T,D,U} = U()
+@inline unit(x::AbstractQuantity{T,D,U}) where {T,D,U} = U()
+@inline unit(::Type{<:AbstractQuantity{T,D,U}}) where {T,D,U} = U()
 
 
 """
@@ -145,7 +145,7 @@ the same promotion unit, which may be an affine unit, so take care.
 """
 function absoluteunit end
 
-absoluteunit(x::Quantity{T,D,U}) where {T,D,U} = absoluteunit(U())
+absoluteunit(x::AbstractQuantity{T,D,U}) where {T,D,U} = absoluteunit(U())
 absoluteunit(::FreeUnits{N,D,A}) where {N,D,A} = FreeUnits{N,D}()
 absoluteunit(::ContextUnits{N,D,P,A}) where {N,D,P,A} = ContextUnits{N,D,P}()
 absoluteunit(::FixedUnits{N,D,A}) where {N,D,A} = FixedUnits{N,D}()
@@ -220,8 +220,8 @@ julia> typeof(dimension(1.0u"m/μm"))
 Unitful.Dimensions{()}
 ```
 """
-@inline dimension(x::Quantity{T,D}) where {T,D} = D
-@inline dimension(::Type{Quantity{T,D,U}}) where {T,D,U} = D
+@inline dimension(x::AbstractQuantity{T,D}) where {T,D} = D
+@inline dimension(::Type{<:AbstractQuantity{T,D,U}}) where {T,D,U} = D
 
 @deprecate(dimension(x::AbstractArray{T}) where {T<:Number}, dimension.(x))
 @deprecate(dimension(x::AbstractArray{T}) where {T<:Units}, dimension.(x))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -326,6 +326,13 @@ end
 
         @test @inferred(upreferred(1N)) === 1*kg*m/s^2
         @test ismissing(upreferred(missing))
+
+        # preferred units work on AbstractQuantity
+        struct QQQ <: Unitful.AbstractQuantity{Float64,𝐋,typeof(cm)}
+            val::Float64
+        end
+        Unitful.uconvert(U::Unitful.Units, q::QQQ) = uconvert(U, Quantity(q.val, cm))
+        @test @inferred(upreferred(QQQ(10))) == 0.1m
     end
     @testset "> promote_unit" begin
         @test Unitful.promote_unit(FreeUnits(m)) === FreeUnits(m)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -308,6 +308,12 @@ include("dates.jl")
     end
 end
 
+# preferred units work on AbstractQuantity
+struct QQQ <: Unitful.AbstractQuantity{Float64,𝐋,typeof(cm)}
+    val::Float64
+end
+Unitful.uconvert(U::Unitful.Units, q::QQQ) = uconvert(U, Quantity(q.val, cm))
+
 @testset "Promotion" begin
     @testset "> Unit preferences" begin
         # Only because we favor SI, we have the following:
@@ -328,10 +334,6 @@ end
         @test ismissing(upreferred(missing))
 
         # preferred units work on AbstractQuantity
-        struct QQQ <: Unitful.AbstractQuantity{Float64,𝐋,typeof(cm)}
-            val::Float64
-        end
-        Unitful.uconvert(U::Unitful.Units, q::QQQ) = uconvert(U, Quantity(q.val, cm))
         @test @inferred(upreferred(QQQ(10))) == 0.1m
     end
     @testset "> promote_unit" begin


### PR DESCRIPTION
I've found a bug in PhysicalConstants.jl due to `upreferred` not being defined for `AbstractQuantity`

```julia
julia> using Unitful

julia> import PhysicalConstants.CODATA2018 as c

julia> Unitful.preferunits(u"cm,g,s"...)

julia> c.G |> upreferred
Newtonian constant of gravitation (G)
Value                         = 6.6743e-11 m³ kg⁻¹ s⁻²
Standard uncertainty          = 1.5e-15 m³ kg⁻¹ s⁻²
Relative standard uncertainty = 2.2e-5
Reference                     = CODATA 2018
```
with this PR-
```julia
julia> c.G |> upreferred
6.674299999999999e-8 cm³ g⁻¹ s⁻²
```
---

I've gone through some of the methods defined for `Quantity` and made sure they work with `AbstractQuantity`. Something I noticed is that `uconvert(::Units, ::AbstractQuantity)` has to be defined in order to enable `upreferred`, because the default `uconvert` for `Quantity` references `x.val`. In the future, this could be written generically if a `Unitful.value` interface is introduced to `AbstractQuantity`.

I wouldn't say I've done a thorough search of the code for methods to replace, but rather just enough to get the `upreferred` working so I can address a user's use case.