### PR TITLE
Add link to UnitfulBuckinghamPi in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ mathematical operations and collections that are found in Julia base.
 - [UnitfulIntegration.jl](https://github.com/PainterQubits/UnitfulIntegration.jl): Enables use of Unitful quantities with [QuadGK.jl](https://github.com/JuliaMath/QuadGK.jl). PRs for other integration packages are welcome.
 - [UnitfulEquivalences.jl](https://github.com/sostock/UnitfulEquivalences.jl): Enables conversion between equivalent quantities of different dimensions, e.g. between energy and wavelength of a photon.
 - [UnitfulLatexify.jl](https://github.com/gustaphe/UnitfulLatexify.jl): Pretty print units and quantities in LaTeX format.
+- [UnitfulBuckinghamPi.jl](https://github.com/rmsrosa/UnitfulBuckinghamPi.jl): Solves for the adimensional Pi groups in a list of Unitful parameters, according to the Buckingham-Pi Theorem.
 
 ## Related packages
 


### PR DESCRIPTION
I just registered the [UnitfulBuckinghamPi.jl](https://github.com/rmsrosa/UnitfulBuckinghamPi.jl) package. It solves for the adimensional groups in a list of Unitful parameters (quantities, units, dimensions, or combinations thereof).

This PR adds a link to the package in the README.