### PR TITLE
To certain functions, add the `fancy_exponents` kwarg, which allows the user to toggle the "fancy exponents" setting in a thread-safe way

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Unitful"
 uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
-version = "1.7.0"
+version = "1.8.0"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/src/logarithm.jl
+++ b/src/logarithm.jl
@@ -84,11 +84,11 @@ tolog(L,x) = (1+isrootpower(L)) * prefactor(L()) * (logfn(L()))(x)
 fromlog(L,S,x) = unwrap(S) * expfn(L())( x / ((1+isrootpower(S))*prefactor(L())) )
 fromlog(L,x) = expfn(L())( x / ((1+isrootpower(L))*prefactor(L())) )
 
-function Base.show(io::IO, x::MixedUnits{T,U}) where {T,U}
+function Base.show(io::IO, x::MixedUnits{T,U}; fancy_exponents::Bool = get_fancy_exponents_env()) where {T,U}
     print(io, abbr(x))
     if x.units != NoUnits
         print(io, " ")
-        show(io, x.units)
+        show(io, x.units; fancy_exponents = fancy_exponents)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1299,6 +1299,10 @@ end
         @test string(dimension(1u"m/s")) == "𝐋 𝐓^-1"
         @test string(NoDims) == "NoDims"
     end
+    @testset "fancy_exponents kwarg" begin
+        @test sprint(io -> show(io, u"m/s"; fancy_exponents = true)) == "m s⁻¹"
+        @test sprint(io -> show(io, u"m/s"; fancy_exponents = false)) == "m s^-1"
+    end
 end
 
 struct Foo <: Number end


### PR DESCRIPTION
This pull request adds the `fancy_exponents::Bool` kwarg to several methods of the following functions:
- `show`
- `showval`
- `showrep`
- `superscript`

We use the fancy Unicode exponents if and only if `fancy_exponents` is `true`.

The `fancy_exponents::Bool` kwarg is optional. The default value is determined as follows:
1. If the user explicitly provides the `fancy_exponents` kwarg, we use that value.
2. Otherwise, if the user has set the `UNITFUL_FANCY_EXPONENTS` environment, and the lowercased value parses to a `Bool`, we use that value.
3. Otherwise, if the user has set the `UNITFUL_FANCY_EXPONENTS` environment variable, but the lowercased value does not parse to a `Bool`, we default to `false`.
3. Otherwise, we default to `true` on macOS and `false` otherwise.

Therefore, if the user does not provide the `fancy_exponents` kwarg, this PR preserves the existing behavior.

# Motivation

Currently, the only way to control the behavior of the fancy Unicode exponents is by the `UNITFUL_FANCY_EXPONENTS` environment variable. Unfortunately, as far as I understand, there is no thread-safe way to modify the environment while calling a Julia function. (The `withenv` function is not thread-safe. The `addenv` function is thread-safe, but as far as I can tell, it only lets you run a `Cmd`.)

The `fancy_exponents` kwarg allows the user to turn fancy Unicode exponents on/off in a thread-safe way.