### PR TITLE
Use the `:fancy_exponent` IO context property to override the behavior of fancy exponents

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Unitful"
 uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
-version = "1.7.0"
+version = "1.8.0"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/docs/src/display.md
+++ b/docs/src/display.md
@@ -3,7 +3,8 @@
 By default, exponents on units or dimensions are indicated using Unicode superscripts on
 macOS and without superscripts on other operating systems. You can set the environment
 variable `UNITFUL_FANCY_EXPONENTS` to either `true` or `false` to force using or not using
-the exponents.
+the exponents. You can also set the `:fancy_exponent` IO context property to either `true`
+or `false` to force using or not using the exponents.
 
 ```@docs
 Unitful.BracketStyle

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1299,6 +1299,10 @@ end
         @test string(dimension(1u"m/s")) == "𝐋 𝐓^-1"
         @test string(NoDims) == "NoDims"
     end
+    @testset ":fancy_exponent IOContext property" begin
+        @test sprint(io -> show(IOContext(io, :fancy_exponent => true), u"m/s")) == "m s⁻¹"
+        @test sprint(io -> show(IOContext(io, :fancy_exponent => false), u"m/s")) == "m s^-1"
+    end
 end
 
 struct Foo <: Number end


### PR DESCRIPTION
Before this PR, this is how we determine the behavior of fancy exponents:
1. If the user has set the `UNITFUL_FANCY_EXPONENTS` environment variable, and the lowercased value parses to a `Bool`, we use that value.
2. Otherwise, if the user has set the `UNITFUL_FANCY_EXPONENTS` environment variable, but the lowercased value does not parse to a `Bool`, we default to false.
3. Otherwise, we default to true on macOS and false otherwise.

After this PR, this is how we determine the behavior of fancy exponents:
1. **If the IO has the `:fancy_exponent` IO context property, and the value of `:fancy_exponent` is a `Bool`, we use that value.**
2. If the user has set the `UNITFUL_FANCY_EXPONENTS` environment variable, and the lowercased value parses to a `Bool`, we use that value.
3. Otherwise, if the user has set the `UNITFUL_FANCY_EXPONENTS` environment variable, but the lowercased value does not parse to a `Bool`, we default to false.
4. Otherwise, we default to true on macOS and false otherwise.

Example usage:

```julia
julia> sprint(io -> show(IOContext(io, :fancy_exponent => true), u"m/s"))
"m s⁻¹"

julia> sprint(io -> show(IOContext(io, :fancy_exponent => false), u"m/s"))
"m s^-1"
```