### PR TITLE
Deprecate the `UNITFUL_FANCY_EXPONENTS` environment variable in favor of the `:fancy_exponent` IO context property

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Unitful"
 uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
-version = "1.8.0"
+version = "1.8.1"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/src/display.jl
+++ b/src/display.jl
@@ -215,6 +215,7 @@ function superscript(i::Rational; io::Union{IO, Nothing} = nothing)
     if iocontext_value isa Bool
         fancy_exponent = iocontext_value
     else
+        haskey(ENV, "UNITFUL_FANCY_EXPONENTS") && @warn("the `UNITFUL_FANCY_EXPONENTS` environment variable is deprecated; please use the `:fancy_exponent` IO context property instead", maxlog=1)
         v = get(ENV, "UNITFUL_FANCY_EXPONENTS", Sys.isapple() ? "true" : "false")
         t = tryparse(Bool, lowercase(v))
         fancy_exponent = (t === nothing) ? false : t


### PR DESCRIPTION
Adding a deprecation warning can be done in a non-breaking release.

I didn't actually use `depwarn` for this, because those kinds of deprecation warnings are turned off by default. So instead, I used `@warn` with `maxlog=1`, which ensures that this warning will be shown by default.