### PR TITLE
Introduce `ubasestrip` for easy consistency with SI base units

### DIFF
--- a/docs/src/manipulations.md
+++ b/docs/src/manipulations.md
@@ -33,6 +33,12 @@ Unitful.dimension
 Unitful.ustrip
 ```
 
+## Unit stripping from base units
+
+```@docs
+Unitful.ubasestrip
+```
+
 ## Unit multiplication
 
 ```@docs

--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -27,7 +27,7 @@ import Random
 
 import ConstructionBase: constructorof
 
-export logunit, unit, absoluteunit, dimension, uconvert, ustrip, upreferred
+export logunit, unit, absoluteunit, dimension, uconvert, ustrip, ubasestrip, upreferred
 export @dimension, @derived_dimension, @refunit, @unit, @affineunit, @u_str
 export Quantity, DimensionlessQuantity, NoUnits, NoDims
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -49,6 +49,41 @@ true
 @inline ustrip(x::Quantity) = ustrip(x.val)
 @inline ustrip(x::Missing) = missing
 
+
+"""
+    ubasestrip(q::AbstractQuantity)
+    ubasestrip(u::Unitlike)
+    ubasestrip(s::String)
+
+Returns the numerical value of a quantity resp. conversion factor of a unit expressed in 
+base (preferred) units. This provides an easy way to express different combinations
+of units (and physical constants) in base units, allowing to use Unitful.jl
+(and PhysicalConstants.jl) as a consistent source of information even for "unitless" packages.
+
+```jldoctest
+julia> ubasestrip(2cm) == 2//100
+true
+
+julia> ubasestrip(u"cm") == 2//100
+true
+
+julia> ubasestrip("cm") == 2//100
+true
+```
+
+```
+julia> using PhysicalConstants.CODATA2018
+julia> ubasestrip(AvogadroConstant) == 6.02214076e23
+true
+```
+
+"""
+@inline ubasestrip(q::AbstractQuantity) = ustrip(upreferred(q).val)
+@inline ubasestrip(u::Unitlike) = ubasestrip(1u)
+@inline ubasestrip(s::String) = ubasestrip(1uparse(s))
+
+
+
 """
     ustrip(x::Array{Q}) where {Q <: Quantity}
 Strip units from an `Array` by reinterpreting to type `T`. The resulting

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -115,6 +115,12 @@ end
         @test @inferred(ustrip(Int, mm, 2.0m)) === 2000
         @test @inferred(ustrip(Float32, NoUnits, 5.0u"m"/2.0u"m")) === Float32(2.5)
         @test @inferred(ustrip(Int, NoUnits, 3.0u"m"/1.0u"cm")) === 300
+        # ubasestrip
+        @test @inferred(ubasestrip(3.0m)) === 3.0
+        @test @inferred(ubasestrip(2mm)) === 1//500
+        @test @inferred(ubasestrip(mm)) === 1//1000
+        @test ubasestrip("mm") === 1//1000
+
         # convert
         @test convert(typeof(1mm/m), 3) == 3000mm/m
         @test convert(typeof(1mm/m), 3*NoUnits) == 3000mm/m


### PR DESCRIPTION
The purpose is to allow users to define unitless constants like `mm`,`nm` etc
and to allow consistent calculations with them, and to provide values
of physical constants in a consistent manner.