### PR TITLE
Showing how to manually cancel units

### DIFF
--- a/docs/src/conversion.md
+++ b/docs/src/conversion.md
@@ -300,19 +300,19 @@ in unit cancellation. For instance, `mV/V` is not simplified, although `V/V` is.
 Also, `N*m/J` is not simplified: there is currently no logic to decide
 whether or not units on a dimensionless quantity seem "intentional" or not.
 It is however possible to cancel units manually. In the equivalent examples below,
-it is shown how to cancel the units of 1km/1m:
+it is shown how to cancel the units of 1km/2.5m:
 ```jldoctest
 julia> using Unitful, Unitful.DefaultSymbols
 
 # Converting the units to be equal with `uconvert` for automatic canceling:
-julia> uconvert(m, 1km) / 1m
-1000.0
+julia> uconvert(m, 1km) / 2.5m
+400.0
 
 # Using the unit as a function for conversion instead of `uconvert`
-julia> m(1km) / 1m
-1000.0
+julia> m(1km) / 2.5m
+400.0
 
-# Using the piping operator to convert to the NoUnit type
-julia>  1km/1m |> NoUnit
-1000.0
+# Using the piping operator to convert to the NoUnits type
+julia>  1km/2.5m |> NoUnits
+400.0
 ```

--- a/docs/src/conversion.md
+++ b/docs/src/conversion.md
@@ -300,10 +300,10 @@ in unit cancellation. For instance, `mV/V` is not simplified, although `V/V` is.
 Also, `N*m/J` is not simplified: there is currently no logic to decide
 whether or not units on a dimensionless quantity seem "intentional" or not.
 It is however possible to cancel units manually, by passing the dimentionless
-size to the `NoUnits` constructor. This takes care of different SI-prefixes:
+size to the [`NoUnits`](@ref) constructor. This takes into account different SI-prefixes:
 ```jldoctest
 julia> using Unitful
 
-julia>  1u"km"/4u"m" |> NoUnits
+julia>  julia> 1u"kN*m"/4u"J" |> NoUnits
 250.0
 ```

--- a/docs/src/conversion.md
+++ b/docs/src/conversion.md
@@ -312,7 +312,7 @@ julia> uconvert(m, 1km) / 1m
 julia> m(1km) / 1m
 1000.0
 
-# Using the piping operator to convert to meter/meter:
+# Using the piping operator to convert to m/m, which is automatically canceled:
 julia>  1km/1m |> m/m
 1000.0
 

--- a/docs/src/conversion.md
+++ b/docs/src/conversion.md
@@ -299,20 +299,11 @@ For multiplication and division, note that powers-of-ten prefixes are significan
 in unit cancellation. For instance, `mV/V` is not simplified, although `V/V` is.
 Also, `N*m/J` is not simplified: there is currently no logic to decide
 whether or not units on a dimensionless quantity seem "intentional" or not.
-It is however possible to cancel units manually. In the equivalent examples below,
-it is shown how to cancel the units of 1km/2.5m:
+It is however possible to cancel units manually, by passing the dimentionless
+size to the `NoUnits` constructor. This takes care of different SI-prefixes:
 ```jldoctest
-julia> using Unitful, Unitful.DefaultSymbols
+julia> using Unitful
 
-# Converting the units to be equal with `uconvert` for automatic canceling:
-julia> uconvert(m, 1km) / 2.5m
-400.0
-
-# Using the unit as a function for conversion instead of `uconvert`
-julia> m(1km) / 2.5m
-400.0
-
-# Using the piping operator to convert to the NoUnits type
-julia>  1km/2.5m |> NoUnits
-400.0
+julia>  1u"km"/4u"m" |> NoUnits
+250.0
 ```

--- a/docs/src/conversion.md
+++ b/docs/src/conversion.md
@@ -299,24 +299,20 @@ For multiplication and division, note that powers-of-ten prefixes are significan
 in unit cancellation. For instance, `mV/V` is not simplified, although `V/V` is.
 Also, `N*m/J` is not simplified: there is currently no logic to decide
 whether or not units on a dimensionless quantity seem "intentional" or not.
-It is however possible to cancel units manually. In the hour examples below,
+It is however possible to cancel units manually. In the equivalent examples below,
 it is shown how to cancel the units of 1km/1m:
 ```jldoctest
 julia> using Unitful, Unitful.DefaultSymbols
 
-# Converting the units to be equal with `uconvert`:
+# Converting the units to be equal with `uconvert` for automatic canceling:
 julia> uconvert(m, 1km) / 1m
 1000.0
 
-# Using a unit as a function to convert to it
+# Using the unit as a function for conversion instead of `uconvert`
 julia> m(1km) / 1m
 1000.0
 
-# Using the piping operator to convert to m/m, which is automatically canceled:
-julia>  1km/1m |> m/m
-1000.0
-
-# The units are arbitrary, since the quantity is dimensionless:
-julia>  1km/1m |> J/J
+# Using the piping operator to convert to the NoUnit type
+julia>  1km/1m |> NoUnit
 1000.0
 ```

--- a/docs/src/conversion.md
+++ b/docs/src/conversion.md
@@ -299,3 +299,24 @@ For multiplication and division, note that powers-of-ten prefixes are significan
 in unit cancellation. For instance, `mV/V` is not simplified, although `V/V` is.
 Also, `N*m/J` is not simplified: there is currently no logic to decide
 whether or not units on a dimensionless quantity seem "intentional" or not.
+It is however possible to cancel units manually. In the hour examples below,
+it is shown how to cancel the units of 1km/1m:
+```jldoctest
+julia> using Unitful, Unitful.DefaultSymbols
+
+# Converting the units to be equal with `uconvert`:
+julia> uconvert(m, 1km) / 1m
+1000.0
+
+# Using a unit as a function to convert to it
+julia> m(1km) / 1m
+1000.0
+
+# Using the piping operator to convert to meter/meter:
+julia>  1km/1m |> m/m
+1000.0
+
+# The units are arbitrary, since the quantity is dimensionless:
+julia>  1km/1m |> J/J
+1000.0
+```

--- a/docs/src/conversion.md
+++ b/docs/src/conversion.md
@@ -300,7 +300,7 @@ in unit cancellation. For instance, `mV/V` is not simplified, although `V/V` is.
 Also, `N*m/J` is not simplified: there is currently no logic to decide
 whether or not units on a dimensionless quantity seem "intentional" or not.
 It is however possible to cancel units manually, by passing the dimensionless
-size to the [`NoUnits`](@ref) constructor. This takes into account different SI-prefixes:
+quantity to the [`NoUnits`](@ref) constructor. This takes into account different SI-prefixes:
 ```jldoctest
 julia> using Unitful
 

--- a/docs/src/conversion.md
+++ b/docs/src/conversion.md
@@ -299,7 +299,7 @@ For multiplication and division, note that powers-of-ten prefixes are significan
 in unit cancellation. For instance, `mV/V` is not simplified, although `V/V` is.
 Also, `N*m/J` is not simplified: there is currently no logic to decide
 whether or not units on a dimensionless quantity seem "intentional" or not.
-It is however possible to cancel units manually, by passing the dimentionless
+It is however possible to cancel units manually, by passing the dimensionless
 size to the [`NoUnits`](@ref) constructor. This takes into account different SI-prefixes:
 ```jldoctest
 julia> using Unitful


### PR DESCRIPTION
The doc-section on Unit cancellation currently only states that units with differing SI-prefixes don't get cancelled. In this PR, I have added documentation for ways to cancel the units manually, which I have found very useful.