### PR TITLE
Support `zero` for array with heterogeneous units

### DIFF
--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -376,6 +376,7 @@ zero(x::Type{<:AbstractQuantity{T}}) where {T} = throw(ArgumentError("zero($x) n
 zero(x::Type{<:AbstractQuantity{T,D}}) where {T,D} = zero(T) * upreferred(D)
 zero(x::Type{<:AbstractQuantity{T,D,U}}) where {T,D,U<:ScalarUnits} = zero(T)*U()
 zero(x::Type{<:AbstractQuantity{T,D,U}}) where {T,D,U<:AffineUnits} = zero(T)*absoluteunit(U())
+zero(x::AbstractArray{<:AbstractQuantity}) = map(zero,x)
 
 one(x::AbstractQuantity) = one(x.val)
 one(x::AffineQuantity) =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1281,7 +1281,7 @@ end
             @test size(rand(Q, 2)) == (2,)
             @test size(rand(Q, 2, 3)) == (2,3)
             @test eltype(@inferred(rand(Q, 2))) == Q
-            @test_throws ArgumentError zero([1u"m", 1u"s"])
+            @test zero([1u"m", 1u"s"]) == [0u"m",0u"s"]
             @test zero(Quantity{Int,𝐋}[1u"m", 1u"mm"]) == [0, 0]u"m"
         end
     end


### PR DESCRIPTION
When working with ModelingToolkit, we often would like to have heterogeneous units within an vector of variables. Presently there's no method to create a `zero` array for such a case, which is often needed when doing solves or automatic differentiation. 

This construction only works if an appropriate template array already exists (ie, cannot be done abstractly).  So there's no ambiguity about what the unit type is for each index.