### PR TITLE
Attempt to allow preferunits to work with non-pure units

### DIFF
--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -53,7 +53,7 @@ end
 const basefactors = _basefactors(Unitful)
 
 include("types.jl")
-const promotion = Dict{Symbol,Unit}()
+const promotion = Dict{Symbol,FreeUnits}()
 
 include("user.jl")
 include("utils.jl")

--- a/src/units.jl
+++ b/src/units.jl
@@ -302,6 +302,6 @@ factory defaults, this function will return a product of powers of base SI units
 (as [`Unitful.FreeUnits`](@ref)).
 """
 @generated function upreferred(x::Dimensions{D}) where {D}
-    u = *(FreeUnits{((Unitful.promotion[name(z)]^z.power for z in D)...,),()}())
+    u = prod(Unitful.promotion[name(z)]^z.power for z in D)
     :($u)
 end

--- a/src/units.jl
+++ b/src/units.jl
@@ -302,6 +302,6 @@ factory defaults, this function will return a product of powers of base SI units
 (as [`Unitful.FreeUnits`](@ref)).
 """
 @generated function upreferred(x::Dimensions{D}) where {D}
-    u = prod((Unitful.NoUnits, (Unitful.promotion[name(z)]^z.power for z in D)...))
+    u = prod((NoUnits, (promotion[name(z)]^z.power for z in D)...))
     :($u)
 end

--- a/src/units.jl
+++ b/src/units.jl
@@ -302,6 +302,6 @@ factory defaults, this function will return a product of powers of base SI units
 (as [`Unitful.FreeUnits`](@ref)).
 """
 @generated function upreferred(x::Dimensions{D}) where {D}
-    u = prod(Unitful.promotion[name(z)]^z.power for z in D)
+    u = prod([Unitful.NoUnits, (Unitful.promotion[name(z)]^z.power for z in D)...])
     :($u)
 end

--- a/src/units.jl
+++ b/src/units.jl
@@ -302,6 +302,6 @@ factory defaults, this function will return a product of powers of base SI units
 (as [`Unitful.FreeUnits`](@ref)).
 """
 @generated function upreferred(x::Dimensions{D}) where {D}
-    u = prod([Unitful.NoUnits, (Unitful.promotion[name(z)]^z.power for z in D)...])
+    u = prod((Unitful.NoUnits, (Unitful.promotion[name(z)]^z.power for z in D)...))
     :($u)
 end

--- a/src/user.jl
+++ b/src/user.jl
@@ -318,17 +318,19 @@ function preferunits(u0::Units, u::Units...)
     # unexpected (though still correct) results. There may be cases where people would want to do this,
     # so we won't stop them, just let them know they're doing it.
     ulist = (typeof(i[2]).parameters[1] for i in promotion)
-    ulist = (i^(1/i.power) for i in ulist)
-    check = Dict()
-    for i in ulist
-        k = string(dimension(i))
-        if haskey(check, k)
-            if i!=check[k]
-                @warn "Preferred units contain complex units based on units of the same dimension but different scales: "*string(i)*" and "*string(check[k])*
-                "\nThis may be intentional, but otherwise could lead to redundant units, such as ms/s or kg/g"
+    check = Dict{String, Unit}()
+    for a in ulist
+        ulistA = (i^(1/i.power) for i in a)
+        for i in ulistA
+            k = string(dimension(i))
+            if haskey(check, k)
+                if i!=check[k]
+                    @warn "Preferred units contain complex units based on units of the same dimension but different scales: "*string(i)*" and "*string(check[k])*
+                    "\nThis may be intentional, but otherwise could lead to redundant units, such as ms/s or kg/g"
+                end
+            else
+                check[k] = i
             end
-        else
-            check[k] = i
         end
     end
 

--- a/src/user.jl
+++ b/src/user.jl
@@ -317,14 +317,14 @@ function preferunits(u0::Units, u::Units...)
     # was defined in ns. We'll give a warning if this is the case so the user knows they may get
     # unexpected (though still correct) results. There may be cases where people would want to do this,
     # so we won't stop them, just let them know they're doing it.
-    ulist = [([typeof(i[2]).parameters[1] for i in promotion]...)...]
-    ulist = [i^(1/i.power) for i in ulist]
+    ulist = (typeof(i[2]).parameters[1] for i in promotion)
+    ulist = (i^(1/i.power) for i in ulist)
     check = Dict()
     for i in ulist
         k = string(dimension(i))
         if haskey(check, k)
             if i!=check[k]
-                @warn "Prefered units contain complex units based on units of the same dimension but different scales: "*string(i)*" and "*string(check[k])*
+                @warn "Preferred units contain complex units based on units of the same dimension but different scales: "*string(i)*" and "*string(check[k])*
                 "\nThis may be intentional, but otherwise could lead to redundant units, such as ms/s or kg/g"
             end
         else

--- a/src/user.jl
+++ b/src/user.jl
@@ -310,7 +310,7 @@ function preferunits(u0::Units, u::Units...)
             "For instance, it should not be used with units of dimension 𝐋^2.")
         end
         y = typeof(dim).parameters[1][1]
-        promotion[name(y)] = typeof(unit).parameters[1][1]
+        promotion[name(y)] = unit
     end
 
     nothing

--- a/src/user.jl
+++ b/src/user.jl
@@ -313,6 +313,25 @@ function preferunits(u0::Units, u::Units...)
         promotion[name(y)] = unit
     end
 
+    # Let's run a quick check for anything where, for instance, current was defined is C/ms and time
+    # was defined in ns. We'll give a warning if this is the case so the user knows they may get
+    # unexpected (though still correct) results. There may be cases where people would want to do this,
+    # so we won't stop them, just let them know they're doing it.
+    ulist = [([typeof(i[2]).parameters[1] for i in promotion]...)...]
+    ulist = [i^(1/i.power) for i in ulist]
+    check = Dict()
+    for i in ulist
+        k = string(dimension(i))
+        if haskey(check, k)
+            if i!=check[k]
+                @warn "Prefered units contain complex units based on units of the same dimension but different scales: "*string(i)*" and "*string(check[k])*
+                "\nThis may be intentional, but otherwise could lead to redundant units, such as ms/s or kg/g"
+            end
+        else
+            check[k] = i
+        end
+    end
+
     nothing
 end
 

--- a/src/user.jl
+++ b/src/user.jl
@@ -318,11 +318,11 @@ function preferunits(u0::Units, u::Units...)
     # unexpected (though still correct) results. There may be cases where people would want to do this,
     # so we won't stop them, just let them know they're doing it.
     ulist = (typeof(i[2]).parameters[1] for i in promotion)
-    check = Dict{String, Unit}()
+    check = Dict{Unitful.Dimensions, Unit}()
     for a in ulist
         ulistA = (i^(1/i.power) for i in a)
         for i in ulistA
-            k = string(dimension(i))
+            k = dimension(i)
             if haskey(check, k)
                 if i!=check[k]
                     @warn "Preferred units contain complex units based on units of the same dimension but different scales: "*string(i)*" and "*string(check[k])*

--- a/src/user.jl
+++ b/src/user.jl
@@ -318,7 +318,7 @@ function preferunits(u0::Units, u::Units...)
     # unexpected (though still correct) results. There may be cases where people would want to do this,
     # so we won't stop them, just let them know they're doing it.
     ulist = (typeof(i[2]).parameters[1] for i in promotion)
-    check = Dict{Unitful.Dimensions, Unit}()
+    check = Dict{Dimensions, Unit}()
     for a in ulist
         ulistA = (i^(1/i.power) for i in a)
         for i in ulistA

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -322,7 +322,7 @@ Unitful.uconvert(U::Unitful.Units, q::QQQ) = uconvert(U, Quantity(q.val, cm))
 @testset "Promotion" begin
     @testset "> Unit preferences" begin
         # Should warn on possible redundant units issue (ms and s)
-        @test_logs (:warn,) Unitful.preferunits(C/ms)
+        @test_logs (:warn, r"^Preferred units contain complex units") Unitful.preferunits(C/ms)
         # Test for wacky prefered units functionality
         Unitful.preferunits(C/s)
         @test @inferred(upreferred(u"V/m")) == u"kg*m*C^-1*s^-2"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -325,6 +325,7 @@ Unitful.uconvert(U::Unitful.Units, q::QQQ) = uconvert(U, Quantity(q.val, cm))
         @test_logs (:warn,) Unitful.preferunits(C/ms)
         # Test for wacky prefered units functionality
         Unitful.preferunits(C/s)
+        @test @inferred(preferunits(u"V/m")) == u"kg*m*C^-1*s^-2"
         @test dimension(upreferred(u"V/m")) == dimension(u"V/m")
         # Reset prefered units to default
         Unitful.preferunits(A)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -325,7 +325,7 @@ Unitful.uconvert(U::Unitful.Units, q::QQQ) = uconvert(U, Quantity(q.val, cm))
         @test_logs (:warn,) Unitful.preferunits(C/ms)
         # Test for wacky prefered units functionality
         Unitful.preferunits(C/s)
-        @test @inferred(preferunits(u"V/m")) == u"kg*m*C^-1*s^-2"
+        @test @inferred(upreferred(u"V/m")) == u"kg*m*C^-1*s^-2"
         @test dimension(upreferred(u"V/m")) == dimension(u"V/m")
         # Reset prefered units to default
         Unitful.preferunits(A)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -327,7 +327,8 @@ Unitful.uconvert(U::Unitful.Units, q::QQQ) = uconvert(U, Quantity(q.val, cm))
         Unitful.preferunits(C/s)
         @test @inferred(upreferred(V/m)) == kg*m*C^-1*s^-2
         @test dimension(upreferred(V/m)) == dimension(V/m)
-        # Reset prefered units to default
+        # Reset preferred units to default, except for units of dimension 𝐋*𝐌*𝐈^-1*𝐓^-3,
+        # because upreferred has already been called for that dimension
         Unitful.preferunits(A)
 
         # Only because we favor SI, we have the following:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -325,8 +325,8 @@ Unitful.uconvert(U::Unitful.Units, q::QQQ) = uconvert(U, Quantity(q.val, cm))
         @test_logs (:warn, r"^Preferred units contain complex units") Unitful.preferunits(C/ms)
         # Test for wacky prefered units functionality
         Unitful.preferunits(C/s)
-        @test @inferred(upreferred(u"V/m")) == u"kg*m*C^-1*s^-2"
-        @test dimension(upreferred(u"V/m")) == dimension(u"V/m")
+        @test @inferred(upreferred(V/m)) == kg*m*C^-1*s^-2
+        @test dimension(upreferred(V/m)) == dimension(V/m)
         # Reset prefered units to default
         Unitful.preferunits(A)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,8 @@ import Unitful:
     J, A, N, mol, V,
     mW, W,
     dB, dB_rp, dB_p, dBm, dBV, dBSPL, Decibel,
-    Np, Np_rp, Np_p, Neper
+    Np, Np_rp, Np_p, Neper,
+    C
 
 import Unitful: 𝐋, 𝐓, 𝐍, 𝚯
 
@@ -320,6 +321,14 @@ Unitful.uconvert(U::Unitful.Units, q::QQQ) = uconvert(U, Quantity(q.val, cm))
 
 @testset "Promotion" begin
     @testset "> Unit preferences" begin
+        # Should warn on possible redundant units issue (ms and s)
+        @test_logs (:warn,) Unitful.preferunits(C/ms)
+        # Test for wacky prefered units functionality
+        Unitful.preferunits(C/s)
+        @test dimension(upreferred(u"V/m")) == dimension(u"V/m")
+        # Reset prefered units to default
+        Unitful.preferunits(A)
+
         # Only because we favor SI, we have the following:
         @test @inferred(upreferred(N)) === kg*m/s^2
         @test @inferred(upreferred(dimension(N))) === kg*m/s^2


### PR DESCRIPTION
Should fix #457. Prior to this change, attempts to use something that looked like `preferunits(u"C/ms")` would result in strange behavior, without throwing any sort of errors. Now, that should work nicely. This means that, for example:

```
julia> Unitful.preferunits(u"ms",u"C/ms")

julia> upreferred(50u"A")
1//20 C ms^-1

julia> upreferred(50u"mA*ns")
1//20000000000 C

julia> upreferred(50u"mA/mC")
1//20 ms^-1
```

preferunits still requires units with pure dimensions of power=1.

I ran all of the tests and looked through the rest of the code for anywhere this could cause issues or incompatibilities, and I couldn't find anything, as upreferred(x::Dimensions) and preferunits seem to be the only things that touch the promotions Dict.