### PR TITLE
Feature/natural units

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,11 +3,11 @@ using Documenter, Unitful, Dates
 DocMeta.setdocmeta!(Unitful, :DocTestSetup, :(using Unitful))
 
 makedocs(
-    sitename = "Unitful.jl",
-    format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true"),
-    modules = [Unitful],
-    workdir = joinpath(@__DIR__, ".."),
-    pages = [
+    sitename="Unitful.jl",
+    format=Documenter.HTML(prettyurls=get(ENV, "CI", nothing) == "true"),
+    modules=[Unitful],
+    workdir=joinpath(@__DIR__, ".."),
+    pages=[
         "Home" => "index.md"
         "Highlighted features" => "highlights.md"
         "Types" => "types.md"
@@ -17,6 +17,7 @@ makedocs(
         "How units are displayed" => "display.md"
         "Logarithmic scales" => "logarithm.md"
         "Temperature scales" => "temperature.md"
+        "Natural Units" => "natural_units.md"
         "Interoperability with `Dates`" => "dates.md"
         "Extending Unitful" => "extending.md"
         "Troubleshooting" => "trouble.md"
@@ -24,4 +25,4 @@ makedocs(
     ]
 )
 
-deploydocs(repo = "github.com/PainterQubits/Unitful.jl.git")
+deploydocs(repo="github.com/PainterQubits/Unitful.jl.git")

--- a/docs/src/highlights.md
+++ b/docs/src/highlights.md
@@ -84,6 +84,12 @@ julia> uconvert(u"mW*s", 20u"dBm/Hz")
 100.0 s mW
 ```
 
+## Natural units
+```jldoctest
+julia> natural(1u"kg")
+5.609588650020686e35 eV
+```
+
 ## Units with rational exponents
 
 ```jldoctest

--- a/docs/src/natural_units.md
+++ b/docs/src/natural_units.md
@@ -1,6 +1,6 @@
 # Natural units
 
-The provided function `natural` and `unnatural` can be used to convert to and from [natural units](https://en.wikipedia.org/wiki/Natural_units).
+The provided functions `natural` and `unnatural` can be used to convert to and from [natural units](https://en.wikipedia.org/wiki/Natural_units).
 
 ```@docs
 Unitful.natural

--- a/docs/src/natural_units.md
+++ b/docs/src/natural_units.md
@@ -1,0 +1,8 @@
+# Natural units
+
+The provided function `natural` and `unnatural` can be used to convert to and from [natural units](https://en.wikipedia.org/wiki/Natural_units).
+
+```@docs
+Unitful.natural
+Unitful.unnatural
+```

--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -36,6 +36,9 @@ export @logscale, @logunit, @dB, @B, @cNp, @Np
 export Level, Gain
 export uparse
 
+# For natural units
+export natural, unnatural
+
 const unitmodules = Vector{Module}()
 
 function _basefactors(m::Module)
@@ -69,5 +72,6 @@ include("logarithm.jl")
 include("complex.jl")
 include("pkgdefaults.jl")
 include("dates.jl")
+include("natural_units.jl")
 
 end

--- a/src/natural_units.jl
+++ b/src/natural_units.jl
@@ -1,0 +1,87 @@
+# Original author:
+# Mason Protter: protter@ualberta.ca
+
+setDimPow(D::Dict, x::Unitful.Dimension{T}) where {T} = D[T] = x.power
+
+function dimDict(x::Unitful.Dimensions{T}) where {T}
+    D = Dict{Symbol,Rational}(:Length => 0,
+             :Mass => 0,
+             :Temperature => 0,
+             :Time => 0,
+             :Current => 0)
+    for t in T
+        setDimPow(D, t)
+    end
+    return D
+end
+
+dimDict(x::Unitful.Quantity{T}) where {T} = dimDict(dimension(x))
+
+dimDict(x) = Dict{Symbol,Rational}(:Length => 0, :Mass => 0, :Temperature => 0, :Time => 0, :Current => 0)
+
+
+gettypeparams(::Unitful.FreeUnits{T,U,V}) where {T,U,V} = T, U, V
+const energydimension = gettypeparams(u"GeV")[2]
+
+"""
+    natural(q; base=u"eV")
+
+Convert `q` to natural units based on the units specified by `base`. If `base` is 
+unspecified, `natural` will default to `eV`. Currently, `natural` only supports 
+`base`s with dimensions of energy. For all other `base` you will need to use `unnatrual` '
+to convert.
+
+Examples:
+
+    julia> natural(1u"kg")
+    5.609588650020686e35 eV
+
+    julia> natural(1u"kg", base=u"GeV")
+    5.609588650020685e26 GeV
+
+    julia> natural(1u"m")
+    5.067730759202785e6 eV^-1
+
+    julia> natural(1u"m", base=u"GeV")
+    5.067730759202785e15 GeV^-1
+"""
+natural(q; base=u"eV") = _natural(base, q)
+
+function _natural(base::Unitful.FreeUnits{T,energydimension,U}, q) where {T,U}
+    D = dimDict(q)
+    (α, β, γ, δ, ϕ) = (D[:Length], D[:Mass], D[:Temperature], D[:Time], D[:Current])
+    uconvert(base^(-α - δ + β + γ + ϕ),
+             q * ħc^(-α + ϕ / 2) * ħ^(-δ) * c^(2(β - ϕ / 2)) * k^(γ) * (4π * ϵ0)^(-ϕ / 2))
+end
+
+function _natural(base::Unitful.FreeUnits{T,U,V}, q) where {T,U,V}
+    throw("""natural(q; base)` where `base` has dimensions `$U` has not yet been implemented. Please use a base with dimensions of `energy` and then use `unnatural` to convert to your desired units.""")
+end
+
+"""
+    unnatural(targetUnit, q)
+
+Convert a quantity `q` to units specified by `targetUnits` automatically inserting whatever 
+factors  of `ħ`, `c`, `ϵ₀` and `k` are required to make the conversion work.
+
+Examples:
+
+    julia> unnatural(u"m", 5.067730759202785e6u"eV^-1")
+    1.0 m
+
+    julia> unnatural(u"m/s", 1)
+    2.99792458e8 m s^-1
+
+    julia> unnatural(u"K", 1u"eV")
+    11604.522060401006 K
+"""
+function unnatural(targetUnit, q)
+    natTarget = natural(1targetUnit)
+    natQ = natural(q)
+    ratio = natQ / natTarget
+    if typeof(ratio |> dimension) == Unitful.Dimensions{()}
+        (ratio)targetUnit
+    else
+        throw(Unitful.DimensionError)
+    end
+end

--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -164,6 +164,7 @@ const k  = 1.380_649e-23*(J/K)      # exact, Boltzmann constant
 const R  = Na*k                     # molar gas constant
 const σ  = π^2*k^4/(60*ħ^3*c^2)     # Stefan-Boltzmann constant
 const R∞ = 10_973_731.568_160/m     # (21) Rydberg constant
+const ħc = ħ * c                    # Useful for example for natural units
 @unit u      "u" UnifiedAtomicMassUnit 1.660_539_066_60e-27*kg false # (50)
 
 # Acceleration

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,6 +33,9 @@ import Unitful:
 
 import Unitful: LengthUnits, AreaUnits, MassUnits, TemperatureUnits
 
+# For natural units
+import Unitful: c, ħ, ħc, k
+
 using Dates:
     Dates,
     Nanosecond, Microsecond, Millisecond, Second, Minute, Hour, Day, Week,
@@ -1795,6 +1798,24 @@ end
         @test Base.OrderStyle((1+1im)m) === Base.Unordered()
         @test Base.OrderStyle(Num(1)m) === Base.Unordered()
     end
+end
+
+@testset "Natural units" begin
+    @test natural(1u"m") ≈ uconvert(u"eV^-1", 1u"m" / ħc)
+
+    @test unnatural(u"m", uconvert(u"eV^-1", 1u"m" / ħc)) ≈ 1.0u"m"
+
+    @test natural(1e8u"m/s") ≈ convert(Float64, 1e8u"m/s" / c)
+
+    @test unnatural(u"m/s", convert(Float64, 1e8u"m/s" / c)) ≈ 1e8u"m/s"
+
+    @test natural(1u"kg") ≈ uconvert(u"GeV", 1u"kg" * c^2)
+
+    @test natural(1u"m", base=u"GeV") ≈ uconvert(u"GeV^-1", 1u"m" / ħc)
+
+    @test unnatural(u"K", 1u"eV") ≈ uconvert(u"K", 1u"eV" / k)
+
+    @test unnatural(u"(m/s)^(3/2)", 1) ≈ uconvert(u"(m/s)^(3/2)", 1u"c^(3/2)")
 end
 
 # Test precompiled Unitful extension modules


### PR DESCRIPTION
Many of Unitful.jl users are physicists and in many fields of physics, natural units are used.
There is an awesome package for conversions to and from natural units built on Unitful: [**NaturallyUnitful.jl**](https://github.com/MasonProtter/NaturallyUnitful.jl)

It is a good step to join forces. People not knowing about NaturallyUnitful.jl would benefit of the added two functions (`natural` and `unnatural`). No one needs to install an additional package.

I did include the functionality, tests and docs of NaturallyUnitful.jl
The original author @MasonProtter did agree. I hope that he would also maintain this part in Unitful after merging.

All tests did pass!
I just got this warning (not sure if it is related to the addition):

```
┌ Warning: Symbol m was found in multiple registered unit modules.
│ We will use the one from Main.ShadowUnits.
└ @ Unitful ~/Code/Unitful.jl/src/user.jl:589
```

I did also build with Documenter without errors.

You are free to adjust things.

Would solve https://github.com/PainterQubits/Unitful.jl/issues/37