### PR TITLE
Calculate correct `eltype` when multiplying `StepRangeLen` by `Units`.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Unitful"
 uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
-version = "1.9.0"
+version = "1.9.1"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/src/range.jl
+++ b/src/range.jl
@@ -88,7 +88,8 @@ end
 
 # No need to confuse things by changing the type once units are on there,
 # if we can help it.
-*(r::StepRangeLen, y::Units) = StepRangeLen(r.ref*y, r.step*y, length(r), r.offset)
+*(r::StepRangeLen, y::Units) =
+    StepRangeLen{typeof(zero(eltype(r))*y)}(r.ref*y, r.step*y, length(r), r.offset)
 *(r::LinRange, y::Units) = LinRange(r.start*y, r.stop*y, length(r))
 *(r::StepRange, y::Units) = StepRange(r.start*y, r.step*y, r.stop*y)
 function /(x::Base.TwicePrecision, v::Quantity)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1154,6 +1154,7 @@ end
             @test r[3] === 0.3s
             @test *(1:5, mm, s^-1) === 1mm*s^-1:1mm*s^-1:5mm*s^-1
             @test *(1:5, mm, s^-1, mol^-1) === 1mm*s^-1*mol^-1:1mm*s^-1*mol^-1:5mm*s^-1*mol^-1
+            @test @inferred((0:2) * 3f0m) === StepRangeLen{typeof(0f0m)}(0.0m, 3.0m, 3) # issue #477
         end
     end
     @testset "> Arrays" begin


### PR DESCRIPTION
Closes #477. This PR also changes the version number to v1.9.1 to make a patch release.

Before:
```julia
julia> (1.0f0:3.0f0) * u"m" |> eltype # contains Float64-based quantities (wrong)
Quantity{Float64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}
```


After:
```julia
julia> (1.0f0:3.0f0) * u"m" |> eltype # contains Float32-based quantities (correct)
Quantity{Float32, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}
```