### PR TITLE
Use aggressive constprop for `^(::AbstractQuantity, ::Rational)`

### DIFF
--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -470,7 +470,11 @@ Base.literal_pow(::typeof(^), x::AbstractQuantity, ::Val{v}) where {v} =
 
 # All of these are needed for ambiguity resolution
 ^(x::AbstractQuantity, y::Integer) = Quantity((x.val)^y, unit(x)^y)
-^(x::AbstractQuantity, y::Rational) = Quantity((x.val)^y, unit(x)^y)
+@static if VERSION ≥ v"1.8.0-DEV.501"
+    Base.@constprop(:aggressive, ^(x::AbstractQuantity, y::Rational) = Quantity((x.val)^y, unit(x)^y))
+else
+    ^(x::AbstractQuantity, y::Rational) = Quantity((x.val)^y, unit(x)^y)
+end
 ^(x::AbstractQuantity, y::Real) = Quantity((x.val)^y, unit(x)^y)
 
 Base.rand(r::Random.AbstractRNG, ::Random.SamplerType{<:AbstractQuantity{T,D,U}}) where {T,D,U} =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -632,15 +632,17 @@ end
         @test (8m)^(1//3) === 2.0*m^(1//3)
         @test @inferred(cis(90°)) ≈ im
 
-        # Test inferrability of integer literal powers
+        # Test inferrability of literal powers
         _pow_m3(x) = x^-3
         _pow_0(x) = x^0
         _pow_3(x) = x^3
         _pow_2_3(x) = x^(2//3)
 
-        @test_throws ErrorException @inferred(_pow_2_3(m))
-        @test_throws ErrorException @inferred(_pow_2_3(𝐋))
-        @test_throws ErrorException @inferred(_pow_2_3(1.0m))
+        @static if VERSION ≥ v"1.8.0-DEV.501"
+            @test @inferred(_pow_2_3(m)) == m^(2//3)
+            @test @inferred(_pow_2_3(𝐋)) == 𝐋^(2//3)
+            @test @inferred(_pow_2_3(1.0m)) == 1.0m^(2//3)
+        end
 
         @test @inferred(_pow_m3(m)) == m^-3
         @test @inferred(_pow_0(m)) == NoUnits


### PR DESCRIPTION
`^(::Dimension, ::Rational)` and `^(::Units, ::Rational)` can be inferred on master. For `^(::AbstractQuantity, ::Rational)`, `@constprop :aggressive` is necessary. This fixes the test failures on master.