### PR TITLE
Use OpenLibm_jll.libopenlibm instead of FastMath.libm

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,10 +6,12 @@ version = "1.9.0"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+OpenLibm_jll = "05823500-19ac-5b8b-9628-191a04bc5112"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 ConstructionBase = "1"
+OpenLibm_jll = "0.7, 0.8"
 julia = "1"
 
 [extras]

--- a/src/fastmath.jl
+++ b/src/fastmath.jl
@@ -35,8 +35,9 @@ import Base.FastMath: @fastmath,
     minmax_fast,
     cis_fast,
     angle_fast,
-    fast_op,
-    libm
+    fast_op
+
+import OpenLibm_jll: libopenlibm
 
 sub_fast(x::Quantity{T}) where {T <: FloatTypes} = typeof(x)(neg_float_fast(x.val))
 
@@ -167,9 +168,9 @@ for f in (:cos, :sin, :tan)
     f_fast = fast_op[f]
     @eval begin
         $f_fast(x::DimensionlessQuantity{Float32,U}) where {U} =
-            ccall(($(string(f,"f")),libm), Float32, (Float32,), uconvert(x,NoUnits))
+            ccall(($(string(f,"f")),libopenlibm), Float32, (Float32,), uconvert(x,NoUnits))
         $f_fast(x::DimensionlessQuantity{Float64,U}) where {U} =
-            ccall(($(string(f)),libm), Float64, (Float64,), uconvert(x,NoUnits))
+            ccall(($(string(f)),libopenlibm), Float64, (Float64,), uconvert(x,NoUnits))
     end
 end
 


### PR DESCRIPTION
Fixes a warning when precompiling `Unitful` on nightly.  Similar to https://github.com/JuliaMath/SpecialFunctions.jl/pull/344