### PR TITLE
Fix `broadcasted` method ambiguity

### DIFF
--- a/src/range.jl
+++ b/src/range.jl
@@ -108,3 +108,7 @@ broadcasted(::DefaultArrayStyle{1}, ::typeof(*), r::StepRangeLen{T}, x::Abstract
     broadcasted(DefaultArrayStyle{1}(), *, r, ustrip(x)) * unit(x)
 broadcasted(::DefaultArrayStyle{1}, ::typeof(*), x::AbstractQuantity, r::StepRangeLen{T}) where T =
     broadcasted(DefaultArrayStyle{1}(), *, ustrip(x), r) * unit(x)
+broadcasted(::DefaultArrayStyle{1}, ::typeof(*), r::LinRange, x::AbstractQuantity) =
+    LinRange(r.start*x, r.stop*x, r.len)
+broadcasted(::DefaultArrayStyle{1}, ::typeof(*), x::AbstractQuantity, r::LinRange) =
+    LinRange(x*r.start, x*r.stop, r.len)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1164,6 +1164,10 @@ end
             @test *(1:5, mm, s^-1, mol^-1) === 1mm*s^-1*mol^-1:1mm*s^-1*mol^-1:5mm*s^-1*mol^-1
             @test @inferred((0:2) * 3f0m) === StepRangeLen{typeof(0f0m)}(0.0m, 3.0m, 3) # issue #477
             @test @inferred(3f0m * (0:2)) === StepRangeLen{typeof(0f0m)}(0.0m, 3.0m, 3) # issue #477
+            @test @inferred((0f0:2f0) * 3f0m) === 0f0m:3f0m:6f0m
+            @test @inferred(3f0m * (0.0:2.0)) === 0.0m:3.0m:6.0m
+            @test @inferred(LinRange(0f0, 1f0, 3) * 3f0m) === LinRange(0f0m, 3f0m, 3)
+            @test @inferred(3f0m * LinRange(0.0, 1.0, 3)) === LinRange(0.0m, 3.0m, 3)
             @test @inferred(1.0s * range(0.1, step=0.1, length=3)) === @inferred(range(0.1, step=0.1, length=3) * 1.0s)
         end
     end


### PR DESCRIPTION
#489 actually introduced a new ambiguity:
```julia
julia> 1u"m" * LinRange(1,2,3)
ERROR: MethodError: broadcasted(::Base.Broadcast.DefaultArrayStyle{1}, ::typeof(*), ::Quantity{Int64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}, ::LinRange{Float64}) is ambiguous. Candidates:
  broadcasted(::Base.Broadcast.DefaultArrayStyle{1}, ::typeof(*), x::Number, r::LinRange) in Base.Broadcast at broadcast.jl:1138
  broadcasted(::Base.Broadcast.DefaultArrayStyle{1}, ::typeof(*), x::Unitful.AbstractQuantity, r::AbstractRange) in Unitful at /home/sebastian/Development/Unitful.jl/src/range.jl:104
Possible fix, define
  broadcasted(::Base.Broadcast.DefaultArrayStyle{1}, ::typeof(*), ::Unitful.AbstractQuantity, ::LinRange)
```
This PR fixes that.

This time I have actually checked (with `Test.detect_ambiguities`) that there are no `broadcasted` ambiguities. Of course, there are still other ambiguities (see #439).