### PR TITLE
make `norm` use `norm` rather than `abs`

### DIFF
--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -405,8 +405,7 @@ real(x::AbstractQuantity) = Quantity(real(x.val), unit(x))
 imag(x::AbstractQuantity) = Quantity(imag(x.val), unit(x))
 conj(x::AbstractQuantity) = Quantity(conj(x.val), unit(x))
 
-@inline norm(x::AbstractQuantity, p::Real=2) =
-    p == 0 ? (x==zero(x) ? typeof(abs(x))(0) : typeof(abs(x))(1)) : abs(x)
+@inline norm(x::AbstractQuantity, p::Real=2) = Quantity(norm(x.val), unit(x))
 
 """
     sign(x::AbstractQuantity)

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -405,7 +405,7 @@ real(x::AbstractQuantity) = Quantity(real(x.val), unit(x))
 imag(x::AbstractQuantity) = Quantity(imag(x.val), unit(x))
 conj(x::AbstractQuantity) = Quantity(conj(x.val), unit(x))
 
-@inline norm(x::AbstractQuantity, p::Real=2) = Quantity(norm(x.val), unit(x))
+@inline norm(x::AbstractQuantity, p::Real=2) = Quantity(norm(x.val, p), unit(x))
 
 """
     sign(x::AbstractQuantity)


### PR DESCRIPTION
Currently `norm(u"s"*1)` returns `1 s`. After it returns `1.0 s`. The reasoning for this change is to improve consistency with LinearAlgebra which makes the `norm` for `Integer` be the floating point equivalent.