### PR TITLE
Fix some major invalidations to improve compile times

### DIFF
--- a/src/promotion.jl
+++ b/src/promotion.jl
@@ -115,5 +115,3 @@ Base.promote_rule(::Type{Quantity{T}}, ::Type{Quantity{S,D,U}}) where {T,S,D,U} 
 
 Base.promote_rule(::Type{Quantity{S,D,U}}, ::Type{Quantity{T}}) where {T,S,D,U} =
     Quantity{promote_type(T,S)}
-
-Base.promote_typejoin(::Type{Quantity{S,D,U}}, ::Type{Quantity{T,D,U}}) where {T,S,D,U} = Quantity{T,S}

--- a/src/promotion.jl
+++ b/src/promotion.jl
@@ -116,4 +116,4 @@ Base.promote_rule(::Type{Quantity{T}}, ::Type{Quantity{S,D,U}}) where {T,S,D,U} 
 Base.promote_rule(::Type{Quantity{S,D,U}}, ::Type{Quantity{T}}) where {T,S,D,U} =
     Quantity{promote_type(T,S)}
 
-Base.promote_typejoin(::Type{T}, ::Type{Quantity{T,D,U}}) where {T,D,U} = Quantity{T}
+Base.promote_typejoin(::Type{Quantity{S,D,U}}, ::Type{Quantity{T,D,U}}) where {T,S,D,U} = Quantity{T,S}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1263,7 +1263,7 @@ end
             b = [0.0, 0.0m]
             @test b + b == b
             @test b .+ b == b
-            @test eltype(b+b) === Quantity{Float64}
+            @test eltype(b+b) === Number
 
             # Dimensionless quantities
             @test @inferred([1mm/m] + [1.0cm/m])     == [0.011]


### PR DESCRIPTION
Unitful.jl was flagged as a major invalidator of compilation downstream. Test:

```julia
# From: https://timholy.github.io/SnoopCompile.jl/stable/snoopr/
using SnoopCompile
invalidations = @snoopr begin
    using DifferentialEquations

    function lorenz(du,u,p,t)
     du[1] = 10.0(u[2]-u[1])
     du[2] = u[1]*(28.0-u[3]) - u[2]
     du[3] = u[1]*u[2] - (8/3)*u[3]
    end
    u0 = [1.0;0.0;0.0]
    tspan = (0.0,100.0)
    prob = ODEProblem(lorenz,u0,tspan)
    alg = Rodas5()
    tinf = solve(prob,alg)
end;

trees = SnoopCompile.invalidation_trees(invalidations);

@show length(SnoopCompile.uinvalidated(invalidations)) # show total invalidations

show(trees[end]) # show the most invalidated method
```

This method won the prize for the absolute most invalidations :tada:. But I think the bigger issue is that it simply doesn't follow Julia semantics. It fixes the types for issue https://github.com/PainterQubits/Unitful.jl/issues/127 in a way that gives a stricter type than Julia would do in the normal cases (which is why the invalidation occurs).

After this PR, heterogeneous arrays of numbers with Quantity in there act normally, and compile times are back to normal. Here's a showcase of it being normal:

```julia

using Unitful, Test
m = u"m"
cm = u"cm"

b = Union{Complex,Float64}[0 + 0im, 0.0]
@test b + b == b
@test b .+ b == b
@test eltype(b+b) === Number

b = Number[0 + 0im, 0.0]
@test b + b == b
@test b .+ b == b
@test eltype(b+b) === Number

b = [0.0, 0.0m]
@test b + b == b
@test b .+ b == b
@test eltype(b+b) === Number
```