### PR TITLE
Fix printing of `StepRangeLen` with complex elements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Unitful"
 uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
-version = "1.10.2"
+version = "1.10.1"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Unitful"
 uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
-version = "1.10.1"
+version = "1.10.2"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/src/display.jl
+++ b/src/display.jl
@@ -131,7 +131,7 @@ function show(io::IO, mime::MIME"text/plain", x::Quantity)
     end
 end
 
-function show(io::IO, r::Union{StepRange{T},StepRangeLen{T}}) where T<:Quantity
+function show(io::IO, r::StepRange{T}) where T<:Quantity
     a,s,b = first(r), step(r), last(r)
     U = unit(a)
     print(io, '(')
@@ -140,6 +140,16 @@ function show(io::IO, r::Union{StepRange{T},StepRangeLen{T}}) where T<:Quantity
     else
         show(io, ustrip(U, a):ustrip(U, s):ustrip(U, b))
     end
+    print(io, ')')
+    has_unit_spacing(U) && print(io,' ')
+    show(io, U)
+end
+
+function show(io::IO, r::StepRangeLen{T}) where T<:Quantity
+    a,s,b = first(r), step(r), last(r)
+    U = unit(a)
+    print(io, '(')
+    show(io, StepRangeLen(ustrip(U, a), ustrip(U, s), length(r)))
     print(io, ')')
     has_unit_spacing(U) && print(io,' ')
     show(io, U)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1384,6 +1384,8 @@ Base.show(io::IO, ::MIME"text/plain", ::Foo) = print(io, "42.0")
         @test repr((1:10)*u"kg/m^3") == "(1:10) kg m^-3"
         @test repr((1.0:0.1:10.0)*u"kg/m^3") == "(1.0:0.1:10.0) kg m^-3"
         @test repr((1:10)*°) == "(1:10)°"
+        @test repr(range(1.0+2.0im, length=5)*u"m") == "(1.0 + 2.0im:1.0 + 0.0im:5.0 + 2.0im) m"
+        @test repr(range(1+2im, step=1+1im, length=5)*u"m") == "(1 + 2im:1 + 1im:5 + 6im) m"
     end
     withenv("UNITFUL_FANCY_EXPONENTS" => true) do
         @test repr(1.0 * u"m * s * kg^(-1//2)") == "1.0 m s kg⁻¹ᐟ²"


### PR DESCRIPTION
`StepRangeLen` supports complex values, but printing them errors because the `show` method creates another range in a way that is not supported for complex values. This PR fixes that.

Before:
```
julia> range((1+2im)u"m", step=1u"m", length=5)
(Error showing value of type StepRangeLen{Quantity{Complex{Int64}, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}, Quantity{Complex{Int64}, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}, Quantity{Complex{Int64}, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}, Int64}:
ERROR: MethodError: no method matching isless(::Complex{Int64}, ::Complex{Int64})
[...]
```

After:
```
julia> range((1+2im)u"m", step=1u"m", length=5)
(1 + 2im:1 + 0im:5 + 2im) m
```