### PR TITLE
Enable `zero` for arrays with non-concrete eltype

### DIFF
--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -404,7 +404,7 @@ function zero(x::AbstractArray{T}) where T<:AbstractQuantity
         dest
     end
 end
-@static if VERSION < v"1.8.0-DEV"
+@static if VERSION < v"1.8.0-DEV.107"
     function zero(x::AbstractArray{Union{T,Missing}}) where T<:AbstractQuantity # only matches _concrete_ T ...
         @assert isconcretetype(T) # ... but check anyway
         z = zero(T)

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -388,6 +388,30 @@ zero(x::Type{<:AbstractQuantity{T,D}}) where {T,D} = zero(T) * upreferred(D)
 zero(x::Type{<:AbstractQuantity{T,D,U}}) where {T,D,U<:ScalarUnits} = zero(T)*U()
 zero(x::Type{<:AbstractQuantity{T,D,U}}) where {T,D,U<:AffineUnits} = zero(T)*absoluteunit(U())
 
+function zero(x::AbstractArray{T}) where T<:AbstractQuantity
+    if isconcretetype(T)
+        z = zero(T)
+        fill!(similar(x, typeof(z)), z)
+    else
+        dest = similar(x)
+        for i = eachindex(x)
+            if isassigned(x, i...)
+                dest[i] = zero(x[i])
+            else
+                dest[i] = zero(T)
+            end
+        end
+        dest
+    end
+end
+@static if VERSION < v"1.8.0-DEV"
+    function zero(x::AbstractArray{Union{T,Missing}}) where T<:AbstractQuantity # only matches _concrete_ T ...
+        @assert isconcretetype(T) # ... but check anyway
+        z = zero(T)
+        fill!(similar(x, typeof(z)), z)
+    end
+end
+
 one(x::AbstractQuantity) = one(x.val)
 one(x::AffineQuantity) =
     throw(AffineError("no multiplicative identity for affine quantity $x."))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1400,8 +1400,26 @@ end
             @test size(rand(Q, 2)) == (2,)
             @test size(rand(Q, 2, 3)) == (2,3)
             @test eltype(@inferred(rand(Q, 2))) == Q
-            @test_throws ArgumentError zero([1u"m", 1u"s"])
-            @test zero(Quantity{Int,𝐋}[1u"m", 1u"mm"]) == [0, 0]u"m"
+            @test zero([1m, 2m]) == [0m, 0m]
+            @test zero(Quantity{Int,𝐋}[1m, 1mm]) == [0m, 0mm]
+            @test zero(Quantity{Int}[1m, 1s]) == [0m, 0s]
+            @test zero(Quantity[1m, 1s]) == [0m, 0s]
+            @test zero([1mm, missing]) == [0mm, 0mm]
+            @test zero(Union{typeof(0.0s),Missing}[missing]) == [0.0s]
+            @test_broken zero(Union{Quantity{Int,𝐋},Missing}[1mm, missing]) == [0mm, 0m]
+            @test_broken zero(Union{Quantity{Float64,𝐋},Missing}[1.0mm, missing]) == [0.0mm, 0.0m]
+            @test_broken zero(Union{Quantity,Missing}[1m, 1mm]) == [0m, 0mm]
+            @test zero([1°C, 2°C]) == [0K, 0K]
+            @test zero(Quantity[1°C, 2°F]) == [0K, 0K]
+            @test zero(Union{typeof(0°C),Missing}[missing]) == [0K]
+            @test_broken zero(Union{Quantity{Int,𝚯},Missing}[1°C, 2°F, missing]) == [0K, 0K, 0K]
+            @test zero(Vector{typeof(big(1)mm)}(undef, 1)) == [big(0)mm]
+            @test zero(Vector{Union{typeof(big(1)mm),Missing}}(undef, 1)) == [big(0)mm]
+            @test zero(Vector{Quantity{Float64,𝐋}}(undef, 1)) == [0.0m]
+            @test_broken zero(Vector{Union{Quantity{Float64,𝐋},Missing}}(undef, 1)) == [0.0m]
+            @test_throws MethodError zero(Union{Quantity,Missing}[1m, 1s, missing])
+            @test_throws MethodError zero(Vector{Quantity}(undef, 1))
+            @test_throws MethodError zero(Vector{Union{Quantity,Missing}}(undef, 1))
         end
     end
 end


### PR DESCRIPTION
Replaces #472.

This enables `zero(::AbstractArray{T})` for non-concrete `T<:AbstractQuantity` by calling `zero` on each element *if the element is defined* and calling `zero(T)` otherwise.

Support for `Union{T,Missing}` with *concrete* `T<:AbstractQuantity` is added as well (this is only necessary on Julia < 1.8, on master it works without specialized method).

Support for `Union{T,Missing}` with *non-concrete* `T<:AbstractQuantity` is not added (tests for it are added with `@test_broken`) because `zero(::AbstractArray{Union{T,Missing}}) where T<:AbstractQuantity` only matches concrete `T` and `zero(::AbstractArray{T}) where T<:Union{AbstractQuantity,Missing}` would be type piracy.