### PR TITLE
Delete export of `convertr`, `convertrp`

### DIFF
--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -31,7 +31,7 @@ export logunit, unit, absoluteunit, dimension, uconvert, ustrip, upreferred
 export @dimension, @derived_dimension, @refunit, @unit, @affineunit, @u_str
 export Quantity, DimensionlessQuantity, NoUnits, NoDims
 
-export uconvertp, uconvertrp, convertr, convertrp, reflevel, linear
+export uconvertp, uconvertrp, convertrp, reflevel, linear
 export @logscale, @logunit, @dB, @B, @cNp, @Np
 export Level, Gain
 export uparse

--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -31,7 +31,7 @@ export logunit, unit, absoluteunit, dimension, uconvert, ustrip, upreferred
 export @dimension, @derived_dimension, @refunit, @unit, @affineunit, @u_str
 export Quantity, DimensionlessQuantity, NoUnits, NoDims
 
-export uconvertp, uconvertrp, convertrp, reflevel, linear
+export uconvertp, uconvertrp, reflevel, linear
 export @logscale, @logunit, @dB, @B, @cNp, @Np
 export Level, Gain
 export uparse


### PR DESCRIPTION
There is no `convertr`, `convertrp`, so don't export them.