### PR TITLE
Add `modf`

### DIFF
--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -119,6 +119,7 @@ end
 Base.mod2pi(x::DimensionlessQuantity) = mod2pi(uconvert(NoUnits, x))
 Base.mod2pi(x::AbstractQuantity{S, NoDims, <:Units{(Unitful.Unit{:Degree, NoDims}(0, 1//1),),
     NoDims}}) where S = mod(x, 360°)
+Base.modf(x::DimensionlessQuantity) = modf(uconvert(NoUnits, x))
 
 # Addition / subtraction
 for op in [:+, :-]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -631,6 +631,8 @@ end
         @test mod2pi(360°) === 0°           # 2pi is 360°
         @test mod2pi(0.5pi*u"m/dm") ≈ pi    # just testing the dimensionless fallback
         @test modf(2.5rad) === (0.5, 2.0)
+        @test modf(-250cm/m) === (-1//2, -2//1)
+        @test_throws MethodError modf(1m)
         @test @inferred(inv(s)) === s^-1
         @test inv(ContextUnits(m,km)) === ContextUnits(m^-1,km^-1)
         @test inv(FixedUnits(m)) === FixedUnits(m^-1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -630,6 +630,7 @@ end
         @test mod(1hr+3minute+5s, 24s) == 17s
         @test mod2pi(360°) === 0°           # 2pi is 360°
         @test mod2pi(0.5pi*u"m/dm") ≈ pi    # just testing the dimensionless fallback
+        @test modf(2.5rad) === (0.5, 2.0)
         @test @inferred(inv(s)) === s^-1
         @test inv(ContextUnits(m,km)) === ContextUnits(m^-1,km^-1)
         @test inv(FixedUnits(m)) === FixedUnits(m^-1)


### PR DESCRIPTION
Have added support for `modf`.

Currently `modf` doesn't work:
```julia
julia> modf(2.5u"Å")
ERROR: MethodError: no method matching rem(::Quantity{Float64, 𝐋, Unitful.FreeUnits{(Å,), 𝐋, nothing}}, ::Float64)
Closest candidates are:
  rem(::Any, ::Any, ::RoundingMode{:ToZero}) at ~/Apps/julia/julia-1.7/share/julia/base/div.jl:80
  rem(::Any, ::Any, ::RoundingMode{:Down}) at ~/Apps/julia/julia-1.7/share/julia/base/div.jl:81
  rem(::Any, ::Any, ::RoundingMode{:Up}) at ~/Apps/julia/julia-1.7/share/julia/base/div.jl:82
  ...
Stacktrace:
 [1] modf(x::Quantity{Float64, 𝐋, Unitful.FreeUnits{(Å,), 𝐋, nothing}})
   @ Base.Math ./math.jl:892
 [2] top-level scope
   @ REPL[3]:1
```