### PR TITLE
Avoid deprecated `ustrip(::AbstractArray)`

### DIFF
--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -172,7 +172,7 @@ function inv(x::StridedMatrix{T}) where {T <: AbstractQuantity}
 end
 
 for x in (:istriu, :istril)
-    @eval ($x)(A::AbstractMatrix{T}) where {T <: AbstractQuantity} = ($x)(ustrip(A))
+    @eval ($x)(A::AbstractMatrix{T}) where {T <: AbstractQuantity} = ($x)(ustrip.(A))
 end
 
 # Other mathematical functions


### PR DESCRIPTION
```julia
julia> using Unitful

julia> A = [1/u"s" 1;
        1/u"s"^2 1/u"s"]

2×2 Matrix{Quantity{Int64}}:
 1 s⁻¹      1
 1 s⁻²  1 s⁻¹

julia> # define a position-velocity state vector
       x = [1*u"m", 2*u"m"/u"s"]

2-element Vector{Quantity{Int64}}:


     1 m
 2 m s⁻¹

julia> y = A * x
2-element Vector{Any}:
 3 m s⁻¹
 3 m s⁻²

julia> A \ y
ERROR: ArgumentError: cannot reinterpret `Quantity{Int64}` as `Int64`, type `Quantity{Int64}` is not a bits type
Stacktrace:
 [1] (::Base.var"#throwbits#294")(S::Type, T::Type, U::Type)
   @ Base ./reinterpretarray.jl:16
 [2] reinterpret(#unused#::Type{Int64}, a::Matrix{Quantity{Int64}})
   @ Base ./reinterpretarray.jl:41
 [3] ustrip
   @ ~/projects/UnitfulLinearAlgebra/presentation/dev/Unitful/src/utils.jl:78 [inlined]
 [4] istril(A::Matrix{Quantity{Int64}})
   @ Unitful ~/projects/UnitfulLinearAlgebra/presentation/dev/Unitful/src/quantities.jl:175
 [5] \(A::Matrix{Quantity{Int64}}, B::Vector{Any})
   @ LinearAlgebra /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/LinearAlgebra/src/generic.jl:1100
 [6] top-level scope
   @ REPL[5]:1
```


After this PR

```
julia> A \ y
ERROR: MethodError: no method matching (Quantity{Int64})(::Int64)
Closest candidates are:
  (::Type{T})(::T) where T<:Number at boot.jl:772
  (::Type{T})(::AbstractChar) where T<:Union{AbstractChar, Number} at char.jl:50
  (::Type{T})(::Base.TwicePrecision) where T<:Number at twiceprecision.jl:266
  ...
Stacktrace:
 [1] oneunit(#unused#::Type{Quantity{Int64}})
   @ Base ./number.jl:358
 [2] lutype(T::Type)
   @ LinearAlgebra /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/LinearAlgebra/src/lu.jl:204
 [3] lu(A::Matrix{Quantity{Int64}}, pivot::LinearAlgebra.RowMaximum; check::Bool)
   @ LinearAlgebra /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/LinearAlgebra/src/lu.jl:279
 [4] lu(A::Matrix{Quantity{Int64}}, pivot::LinearAlgebra.RowMaximum) (repeats 2 times)
   @ LinearAlgebra /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/LinearAlgebra/src/lu.jl:278
 [5] \(A::Matrix{Quantity{Int64}}, B::Vector{Any})
   @ LinearAlgebra /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/LinearAlgebra/src/generic.jl:1110
 [6] top-level scope
   @ REPL[5]:1
```

(Still errors, but in a more interesting way!)