### PR TITLE
Fix printing of StepRangeLen with affine units

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -136,7 +136,7 @@ function show(io::IO, r::StepRange{T}) where T<:Quantity
     U = unit(a)
     V = absoluteunit(U)
     print(io, '(')
-    if ustrip(U, s) == 1
+    if ustrip(V, s) == 1
         show(io, ustrip(U, a):ustrip(U, b))
     else
         show(io, ustrip(U, a):ustrip(V, s):ustrip(U, b))

--- a/src/display.jl
+++ b/src/display.jl
@@ -134,11 +134,12 @@ end
 function show(io::IO, r::StepRange{T}) where T<:Quantity
     a,s,b = first(r), step(r), last(r)
     U = unit(a)
+    V = unit(s)
     print(io, '(')
     if ustrip(U, s) == 1
         show(io, ustrip(U, a):ustrip(U, b))
     else
-        show(io, ustrip(U, a):ustrip(U, s):ustrip(U, b))
+        show(io, ustrip(U, a):ustrip(V, s):ustrip(U, b))
     end
     print(io, ')')
     has_unit_spacing(U) && print(io,' ')
@@ -148,8 +149,9 @@ end
 function show(io::IO, r::StepRangeLen{T}) where T<:Quantity
     a,s,b = first(r), step(r), last(r)
     U = unit(a)
+    V = unit(s)
     print(io, '(')
-    show(io, StepRangeLen(ustrip(U, a), ustrip(U, s), length(r)))
+    show(io, StepRangeLen(ustrip(U, a), ustrip(V, s), length(r)))
     print(io, ')')
     has_unit_spacing(U) && print(io,' ')
     show(io, U)

--- a/src/display.jl
+++ b/src/display.jl
@@ -134,7 +134,7 @@ end
 function show(io::IO, r::StepRange{T}) where T<:Quantity
     a,s,b = first(r), step(r), last(r)
     U = unit(a)
-    V = unit(s)
+    V = absoluteunit(U)
     print(io, '(')
     if ustrip(U, s) == 1
         show(io, ustrip(U, a):ustrip(U, b))
@@ -149,7 +149,7 @@ end
 function show(io::IO, r::StepRangeLen{T}) where T<:Quantity
     a,s,b = first(r), step(r), last(r)
     U = unit(a)
-    V = unit(s)
+    V = absoluteunit(U)
     print(io, '(')
     show(io, StepRangeLen(ustrip(U, a), ustrip(V, s), length(r)))
     print(io, ')')

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1486,8 +1486,10 @@ Base.show(io::IO, ::MIME"text/plain", ::Foo) = print(io, "42.0")
         # Concise printing of affine ranges with mixed step unit
         @test repr(StepRange(1u"°C", 1u"K", 3u"°C")) == "(1:1:3) °C"
         @test repr(StepRange(1u"°C", 1.0u"K", 3u"°C")) == "(1.0:1.0:3.0) °C"
+        @test repr(StepRange((0//1)u"°F", 1u"K", (9//1)u"°F")) == "(0//1:9//5:9//1) °F"
         @test repr(StepRangeLen{typeof(1u"°C"),typeof(1u"°C"),typeof(1u"K")}(1u"°C", 1u"K", 3, 1)) == "(1:1:3) °C"
         @test repr(StepRangeLen{typeof(1.0u"°C"),typeof(1.0u"°C"),typeof(1u"K")}(1.0u"°C", 1u"K", 3, 1)) == "(1.0:1.0:3.0) °C"
+        @test repr(StepRangeLen{typeof(1.0u"°F"),typeof(1.0u"°F"),typeof(1u"K")}(0.0u"°F", 1u"K", 6)) == "(0.0:1.8:9.0) °F"
     end
     withenv("UNITFUL_FANCY_EXPONENTS" => true) do
         @test repr(1.0 * u"m * s * kg^(-1//2)") == "1.0 m s kg⁻¹ᐟ²"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1489,9 +1489,14 @@ Base.show(io::IO, ::MIME"text/plain", ::Foo) = print(io, "42.0")
         @test repr(StepRange(1.0u"°C", 1u"K", 3.0u"°C")) == "(1.0:1.0:3.0) °C"
         @test repr(StepRange(1.0u"°C", 1.0u"K", 3.0u"°C")) == "(1.0:1.0:3.0) °C"
         @test repr(StepRange((0//1)u"°F", 1u"K", (9//1)u"°F")) == "(0//1:9//5:9//1) °F"
-        @test repr(StepRangeLen{typeof(1u"°C"),typeof(1u"°C"),typeof(1u"K")}(1u"°C", 1u"K", 3, 1)) == "(1:1:3) °C"
         @test repr(StepRangeLen{typeof(1.0u"°C"),typeof(1.0u"°C"),typeof(1u"K")}(1.0u"°C", 1u"K", 3, 1)) == "(1.0:1.0:3.0) °C"
-        @test repr(StepRangeLen{typeof(1.0u"°F"),typeof(1.0u"°F"),typeof(1u"K")}(0.0u"°F", 1u"K", 6)) == "(0.0:1.8:9.0) °F"
+        @static if VERSION < v"1.5"
+            @test_broken repr(StepRangeLen{typeof(1u"°C"),typeof(1u"°C"),typeof(1u"K")}(1u"°C", 1u"K", 3, 1)) == "(1:1:3) °C"
+            @test_broken repr(StepRangeLen{typeof(1.0u"°F"),typeof(1.0u"°F"),typeof(1u"K")}(0.0u"°F", 1u"K", 6)) == "(0.0:1.8:9.0) °F"
+        else
+            @test repr(StepRangeLen{typeof(1u"°C"),typeof(1u"°C"),typeof(1u"K")}(1u"°C", 1u"K", 3, 1)) == "(1:1:3) °C"
+            @test repr(StepRangeLen{typeof(1.0u"°F"),typeof(1.0u"°F"),typeof(1u"K")}(0.0u"°F", 1u"K", 6)) == "(0.0:1.8:9.0) °F"
+        end
     end
     withenv("UNITFUL_FANCY_EXPONENTS" => true) do
         @test repr(1.0 * u"m * s * kg^(-1//2)") == "1.0 m s kg⁻¹ᐟ²"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1480,6 +1480,12 @@ Base.show(io::IO, ::MIME"text/plain", ::Foo) = print(io, "42.0")
         @test repr((1:10)*°) == "(1:10)°"
         @test repr(range(1.0+2.0im, length=5)*u"m") == "(1.0 + 2.0im:1.0 + 0.0im:5.0 + 2.0im) m"
         @test repr(range(1+2im, step=1+1im, length=5)*u"m") == "(1 + 2im:1 + 1im:5 + 6im) m"
+
+        # Concise printing of affine ranges with mixed step unit
+        @test repr(StepRange(1u"°C", 1u"K", 3u"°C")) == "(1:1:3) °C"
+        @test repr(StepRange(1u"°C", 1.0u"K", 3u"°C")) == "(1.0:1.0:3.0) °C"
+        @test repr(StepRangeLen{typeof(1u"°C"),typeof(1u"°C"),typeof(1u"K")}(1u"°C", 1u"K", 3, 1)) == "(1:1:3) °C"
+        @test repr(StepRangeLen{typeof(1.0u"°C"),typeof(1.0u"°C"),typeof(1u"K")}(1.0u"°C", 1u"K", 3, 1)) == "(1.0:1.0:3.0) °C"
     end
     withenv("UNITFUL_FANCY_EXPONENTS" => true) do
         @test repr(1.0 * u"m * s * kg^(-1//2)") == "1.0 m s kg⁻¹ᐟ²"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1484,8 +1484,10 @@ Base.show(io::IO, ::MIME"text/plain", ::Foo) = print(io, "42.0")
         @test repr(StepRangeLen(1.0u"m", 1.0u"cm", 101)) == "(1.0:0.01:2.0) m"
 
         # Concise printing of affine ranges with mixed step unit
-        @test repr(StepRange(1u"°C", 1u"K", 3u"°C")) == "(1:1:3) °C"
-        @test repr(StepRange(1u"°C", 1.0u"K", 3u"°C")) == "(1.0:1.0:3.0) °C"
+        @test repr(StepRange(1u"°C", 1u"K", 3u"°C")) == "(1:3) °C"
+        @test repr(StepRange(1u"°C", 1.0u"K", 3u"°C")) == "(1:3) °C"
+        @test repr(StepRange(1.0u"°C", 1u"K", 3.0u"°C")) == "(1.0:1.0:3.0) °C"
+        @test repr(StepRange(1.0u"°C", 1.0u"K", 3.0u"°C")) == "(1.0:1.0:3.0) °C"
         @test repr(StepRange((0//1)u"°F", 1u"K", (9//1)u"°F")) == "(0//1:9//5:9//1) °F"
         @test repr(StepRangeLen{typeof(1u"°C"),typeof(1u"°C"),typeof(1u"K")}(1u"°C", 1u"K", 3, 1)) == "(1:1:3) °C"
         @test repr(StepRangeLen{typeof(1.0u"°C"),typeof(1.0u"°C"),typeof(1u"K")}(1.0u"°C", 1u"K", 3, 1)) == "(1.0:1.0:3.0) °C"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1480,6 +1480,8 @@ Base.show(io::IO, ::MIME"text/plain", ::Foo) = print(io, "42.0")
         @test repr((1:10)*°) == "(1:10)°"
         @test repr(range(1.0+2.0im, length=5)*u"m") == "(1.0 + 2.0im:1.0 + 0.0im:5.0 + 2.0im) m"
         @test repr(range(1+2im, step=1+1im, length=5)*u"m") == "(1 + 2im:1 + 1im:5 + 6im) m"
+        @test repr(StepRange((1//1)u"m", 1u"cm", (2//1)u"m")) == "(1//1:1//100:2//1) m"
+        @test repr(StepRangeLen(1.0u"m", 1.0u"cm", 101)) == "(1.0:0.01:2.0) m"
 
         # Concise printing of affine ranges with mixed step unit
         @test repr(StepRange(1u"°C", 1u"K", 3u"°C")) == "(1:1:3) °C"


### PR DESCRIPTION
This fixed a printing issue (#550) with `range` structures (`StepRange`, `StepRangeLen`) defined with `°C` as a primary unit and `K` as a step unit.

Before:
```
julia> StepRange(1u"°C", 1u"K", 3u"°C")
(1//1:-5443//20:3//1) °C

julia> StepRange(1u"°C", 1.0u"K", 3u"°C")
(1.0:-272.15:273.15) °C

julia> StepRangeLen{typeof(1u"°C"),typeof(1u"°C"),typeof(1u"K")}(1u"°C", 1u"K", 3, 1)
(1//1:-5443//20:-5433//10) °C

julia> StepRangeLen{typeof(1.0u"°C"),typeof(1.0u"°C"),typeof(1u"K")}(1.0u"°C", 1u"K", 3, 1)
(1.0:-272.15:-543.3) °C
```

After:
```
julia> StepRange(1u"°C", 1u"K", 3u"°C")
(1:1:3) °C

julia> StepRange(1u"°C", 1.0u"K", 3u"°C")
(1.0:1.0:3.0) °C

julia> StepRangeLen{typeof(1u"°C"),typeof(1u"°C"),typeof(1u"K")}(1u"°C", 1u"K", 3, 1)
(1:1:3) °C

julia> StepRangeLen{typeof(1.0u"°C"),typeof(1.0u"°C"),typeof(1u"K")}(1.0u"°C", 1u"K", 3, 1)
(1.0:1.0:3.0) °C
```