### PR TITLE
Move const `q` under `Constants`

### DIFF
--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -334,13 +334,6 @@ end
 @unit M      "M"        Molar       1mol/L                  true true
 
 # Energy
-"    Unitful.q
-\nA quantity equal to the elementary charge, the charge of a single electron,
-with a value of exactly 1.602,176,634 × 10^-19 C. The letter `q` is used instead of `e` to avoid
-confusion with Euler's number.
-\nDimension: 𝐈 𝐓.
-\nSee Also: [`Unitful.C`](@ref)."
-const q = 1.602_176_634e-19*C        # CODATA 2018; `e` means 2.718...
 "    Unitful.eV
 \nThe electron-volt, a unit of energy, defined as q*V.
 \nDimension: 𝐋^2 𝐌 𝐓^-2.
@@ -431,6 +424,13 @@ h / (2 × q).
 \nDimension: 𝐋^2 𝐌 𝐈^-1 𝐓^-2.
 \nSee also: [`Unitful.h`](@ref), [`Unitful.q`](@ref)."
 const Φ0 = h/(2q)                   # Superconducting magnetic flux quantum
+"    Unitful.q
+\nA quantity equal to the elementary charge, the charge of a single electron,
+with a value of exactly 1.602,176,634 × 10^-19 C. The letter `q` is used instead of `e` to avoid
+confusion with Euler's number.
+\nDimension: 𝐈 𝐓.
+\nSee Also: [`Unitful.C`](@ref)."
+const q = 1.602_176_634e-19*C        # CODATA 2018; avoids naming conflict with `e`
 "    Unitful.me
 \nA quantity representing the rest mass of an electron, equal to 9.109,383,7015
 × 10^-31 kg (the CODATA 2018 recommended value).


### PR DESCRIPTION
This PR moves the definition of the constant `q` under "Constants". See #556.

I also changed the comment on the line defining `q` from "`e` means 2.718..." to "avoid naming conflict with `e`", as I feel the original phrasing could be confused with the `e` in the line that means "times 10 to the power of..."