### PR TITLE
Disallow `StepRange{<:Quantity{<:AbstractFloat}}`

### DIFF
--- a/src/range.jl
+++ b/src/range.jl
@@ -80,6 +80,23 @@ end
         Base._range(nothing, one(stop), stop, len)
 end
 
+Base.steprange_last(start::AbstractQuantity, step, stop::AbstractQuantity) =
+    unitful_steprange_last(start, step, stop)
+Base.steprange_last(start, step::AbstractQuantity, stop) =
+    unitful_steprange_last(start, step, stop)
+Base.steprange_last(start::AbstractQuantity, step::AbstractQuantity, stop::AbstractQuantity) =
+    unitful_steprange_last(start, step, stop)
+
+function unitful_steprange_last(start, step, stop)
+    if isa(start, AbstractQuantity{<:AbstractFloat}) || isa(step, AbstractQuantity{<:AbstractFloat})
+        throw(ArgumentError("StepRange should not be used with floating point"))
+    end
+    if isa(start, AbstractQuantity{<:Integer}) && !isinteger(ustrip(unit(start), start + step))
+        throw(ArgumentError("invalid step for StepRange of Integer-based quantities"))
+    end
+    invoke(Base.steprange_last, Tuple{Any,Any,Any}, start, step, stop)
+end
+
 *(r::AbstractRange, y::Units) = range(first(r)*y, step=step(r)*y, length=length(r))
 
 # first promote start and stop, leaving step alone

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1131,6 +1131,12 @@ end
             @test @inferred(last(range(1m, step=2mm, length=4))) === (503//500)m
             @test_throws DimensionError(1m, 2V) range(1m, step=2V, length=5)
             @test_throws ArgumentError 1m:0m:5m
+            @test_throws ArgumentError StepRange(1.0m, 1mm, 2.0m)
+            @test_throws ArgumentError StepRange(1m, 1f0mm, 2m)
+            @test_throws ArgumentError StepRange{typeof(1.0m),typeof(1mm)}(1m, 1mm, 2m)
+            @test_throws ArgumentError StepRange{typeof(1.0m),typeof(1.0mm)}(1m, 1mm, 2m)
+            @test_throws ArgumentError StepRange{typeof(1m),typeof((1//1)mm)}(1m, 1mm, 2m)
+            @test @inferred(StepRange(1m, (1000//1)mm, 2m)) isa StepRange{typeof(1m), typeof((1000//1)mm)}
         end
         @testset ">> StepRangeLen" begin
             @test isa(@inferred(colon(1.0m, 1m, 5m)), StepRangeLen{typeof(1.0m)})
@@ -1485,9 +1491,9 @@ Base.show(io::IO, ::MIME"text/plain", ::Foo) = print(io, "42.0")
 
         # Concise printing of affine ranges with mixed step unit
         @test repr(StepRange(1u"°C", 1u"K", 3u"°C")) == "(1:3) °C"
-        @test repr(StepRange(1u"°C", 1.0u"K", 3u"°C")) == "(1:3) °C"
-        @test repr(StepRange(1.0u"°C", 1u"K", 3.0u"°C")) == "(1.0:1.0:3.0) °C"
-        @test repr(StepRange(1.0u"°C", 1.0u"K", 3.0u"°C")) == "(1.0:1.0:3.0) °C"
+        @test repr(StepRange(1u"°C", (1//1)u"K", 3u"°C")) == "(1:3) °C"
+        @test repr(StepRange((1//1)u"°C", 1u"K", (3//1)u"°C")) == "(1//1:3//1) °C"
+        @test repr(StepRange((1//1)u"°C", (1//1)u"K", (3//1)u"°C")) == "(1//1:3//1) °C"
         @test repr(StepRange((0//1)u"°F", 1u"K", (9//1)u"°F")) == "(0//1:9//5:9//1) °F"
         @test repr(StepRangeLen{typeof(1.0u"°C"),typeof(1.0u"°C"),typeof(1u"K")}(1.0u"°C", 1u"K", 3, 1)) == "(1.0:1.0:3.0) °C"
         @static if VERSION < v"1.5"


### PR DESCRIPTION
For unitless numbers, `StepRange` enforces certain restrictions:
```julia
julia> StepRange(1.0, 2.0, 3.0)
ERROR: ArgumentError: StepRange should not be used with floating point
[...]

julia> StepRange(1, 1//2, 2)
ERROR: ArgumentError: StepRange{<:Integer} cannot have non-integer step
[...]
```
However, for unitful quantities, these are currently allowed:
```julia
julia> StepRange(1.0u"m", 2.0u"m", 3.0u"m")
(1.0:2.0:3.0) m

julia> StepRange(1u"m", (1//2)u"m", 2u"m")
(1//1:1//2:2//1) m

julia> ans[2]
ERROR: InexactError: Int64(3//2)
[...]
```
After this PR, the restrictions that apply to unitless numbers are also applied to unitful quantities.