### PR TITLE
Remove `istriu`/`istril` methods

### DIFF
--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -171,10 +171,6 @@ function inv(x::StridedMatrix{T}) where {T <: AbstractQuantity}
     reinterpret(Quantity{iq, inv(dimension(T)), typeof(inv(unit(T)))}, m)
 end
 
-for x in (:istriu, :istril)
-    @eval ($x)(A::AbstractMatrix{T}) where {T <: AbstractQuantity} = ($x)(ustrip(A))
-end
-
 # Other mathematical functions
 
 # `fma` and `muladd`

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1393,8 +1393,16 @@ end
                 SymTridiagonal{Int}
         end
         @testset ">> Linear algebra" begin
-            @test istril([1 1; 0 1]u"m") == false
-            @test istriu([1 1; 0 1]u"m") == true
+            @test istril(1m) === true
+            @test istril([1 1; 0 1]m) === false
+            @test istril([1 0; 1 1]K) === true
+            @test istril([1 0; 1 1]°C) === false
+            @test istril([1//1  -5463//20; 1//1 1//1]°C) === true
+            @test istriu(1m) === true
+            @test istriu([1 1; 0 1]m) === true
+            @test istriu([1 1; 0 1]K) === true
+            @test istriu([1 1; 0 1]°C) === false
+            @test istriu([1//1  1//1; -5463//20 1//1]°C) === true
         end
 
         @testset ">> Array initialization" begin


### PR DESCRIPTION
The removed methods are not necessary (the generic fallback works) and are actually wrong in the case of affine units.

Closes #544.