### PR TITLE
Remove UnitfulIntegration.jl from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ mathematical operations and collections that are found in Julia base.
 
 ### Feature additions
 
-- [UnitfulIntegration.jl](https://github.com/PainterQubits/UnitfulIntegration.jl): Enables use of Unitful quantities with [QuadGK.jl](https://github.com/JuliaMath/QuadGK.jl). PRs for other integration packages are welcome.
 - [UnitfulEquivalences.jl](https://github.com/sostock/UnitfulEquivalences.jl): Enables conversion between equivalent quantities of different dimensions, e.g. between energy and wavelength of a photon.
 - [UnitfulLatexify.jl](https://github.com/gustaphe/UnitfulLatexify.jl): Pretty print units and quantities in LaTeX format.
 - [UnitfulBuckinghamPi.jl](https://github.com/rmsrosa/UnitfulBuckinghamPi.jl): Solves for the adimensional Pi groups in a list of Unitful parameters, according to the Buckingham-Pi Theorem.


### PR DESCRIPTION
UnitfulIntegration.jl is also no longer needed, QuadGK can handle Unitful quantities since QuadGK v2.1.0.

I decided to remove the entry (instead of declaring it deprecated like UnitfulRecipes.jl) because it cannot even be installed with Unitful 1.x (it requires Unitful 0.x), so it isn’t relevant to the package in its current state.

Closes #376.