### PR TITLE
Only use U+00C5 for encoding `Å`

### DIFF
--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -581,13 +581,12 @@ earth, a unit of acceleration, defined by standard to be exactly 9.806,65 m / s^
 \nSee Also: [`Unitful.yd`](@ref)."
 @unit mi        "mi"       Mile                 1760yd                  false
 "    Unitful.angstrom
-    Unitful.Å
+    Unitful.Å
 \nThe angstrom, a metric unit of length defined as 1/10 nm.
 \nDimension: [`Unitful.𝐋`](@ref).
 \nSee Also: [`Unitful.nm`](@ref)."
-@unit angstrom  "Å"        Angstrom             (1//10)*nm      false
-# U+00c5 (opt-shift-A on macOS) and U+212b ('\Angstrom' in REPL) look identical:
-@doc @doc(angstrom) const Å = Å = angstrom
+@unit angstrom  "Å"        Angstrom             (1//10)*nm      false
+@doc @doc(angstrom) const Å = angstrom
 
 # Area
 "    Unitful.ac

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1993,6 +1993,11 @@ end
     @test u"ɛ0" === u"ε0"
     @test uparse("ɛ0") === uparse("ε0")
     @test @doc(Unitful.ɛ0) == @doc(Unitful.ε0)
+    # Julia treats Å (U+00C5) and Å (U+212B) as the same
+    @test Unitful.Å === Unitful.Å === Unitful.angstrom
+    @test u"Å" === u"Å"
+    @test uparse("Å") === uparse("Å")
+    @test @doc(Unitful.Å) == @doc(Unitful.Å)
 end
 
 module DocUnits


### PR DESCRIPTION
This is a follow-up to #511. I noticed that `Å` was also encoded in two different ways (U+00C5 and U+212B).
The Unicode standard recommends using U+00C5, so that’s what I did.