### PR TITLE
Fix `*` for numbers with non-commutative multiplication

### DIFF
--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -29,7 +29,11 @@ Quantity(x::Number, y::Units{()}) = x
 *(x::AbstractQuantity, y::Units, z::Units...) = Quantity(x.val, *(unit(x),y,z...))
 *(x::AbstractQuantity, y::AbstractQuantity) = Quantity(x.val*y.val, unit(x)*unit(y))
 
-*(y::Number, x::AbstractQuantity) = *(x,y)
+function *(x::Number, y::AbstractQuantity)
+    y isa AffineQuantity &&
+        throw(AffineError("an invalid operation was attempted with affine quantities: $x*$y"))
+    return Quantity(x*y.val, unit(y))
+end
 function *(x::AbstractQuantity, y::Number)
     x isa AffineQuantity &&
         throw(AffineError("an invalid operation was attempted with affine quantities: $x*$y"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -522,6 +522,13 @@ end
     @test isa(1m^3/s, VolumeFlow)
 end
 
+# A number type with non-commutative multiplication
+struct MatNum <: Number
+    mat::Matrix{Int}
+end
+Base.:(==)(x::MatNum, y::MatNum) = x.mat == y.mat
+Base.:*(x::MatNum, y::MatNum) = MatNum(x.mat*y.mat)
+
 @testset "Mathematics" begin
     @testset "> Comparisons" begin
         # make sure we are just picking one of the arguments, without surprising conversions
@@ -605,11 +612,6 @@ end
         @test @inferred(false*(-Inf*kg)) === -0.0kg       # `false` acts as "strong zero"
         @test typeof(one(eltype([1.0s, 1kg]))) <: Float64 # issue 159, multiplicative identity
         # Multiplicaton can be non-commutative
-        struct MatNum <: Number
-            mat::Matrix{Int}
-        end
-        Base.:(==)(x::MatNum, y::MatNum) = x.mat == y.mat
-        Base.:*(x::MatNum, y::MatNum) = MatNum(x.mat*y.mat)
         @test Quantity(MatNum([1 2; 3 4]), m) * MatNum([5 6; 7 8]) == Quantity(MatNum([19 22; 43 50]), m)
         @test MatNum([5 6; 7 8]) * Quantity(MatNum([1 2; 3 4]), m) == Quantity(MatNum([23 34; 31 46]), m)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -604,6 +604,14 @@ end
         @test @inferred((NaN*kg)*false) === 0.0kg         # `false` acts as "strong zero"
         @test @inferred(false*(-Inf*kg)) === -0.0kg       # `false` acts as "strong zero"
         @test typeof(one(eltype([1.0s, 1kg]))) <: Float64 # issue 159, multiplicative identity
+        # Multiplicaton can be non-commutative
+        struct MatNum <: Number
+            mat::Matrix{Int}
+        end
+        Base.:(==)(x::MatNum, y::MatNum) = x.mat == y.mat
+        Base.:*(x::MatNum, y::MatNum) = MatNum(x.mat*y.mat)
+        @test Quantity(MatNum([1 2; 3 4]), m) * MatNum([5 6; 7 8]) == Quantity(MatNum([19 22; 43 50]), m)
+        @test MatNum([5 6; 7 8]) * Quantity(MatNum([1 2; 3 4]), m) == Quantity(MatNum([23 34; 31 46]), m)
     end
     @testset "> Division" begin
         @test 360° / 2 === 180.0°            # Issue 110


### PR DESCRIPTION
Fixes #607.

There are other methods of `*`, `/`, and `//` that switch the order of a multiplication, but they only apply to types like `Units`, `Real`, `Level`, or `Gain`, for which multiplication is actually commutative.