### PR TITLE
Add docstring to `NoUnits` and add it to the manual

### DIFF
--- a/docs/src/conversion.md
+++ b/docs/src/conversion.md
@@ -42,15 +42,19 @@ results in behavior identical to calling [`uconvert`](@ref).
 
 ### Dimensionless quantities
 
-For dimensionless quantities, `uconvert` can be used to strip the units without
-losing power-of-ten information:
+For dimensionless quantities, `uconvert` can be used with the [`NoUnits`](@ref) unit to
+strip the units without losing power-of-ten information:
 
 ```jldoctest
-julia> uconvert(Unitful.NoUnits, 1.0u"μm/m")
+julia> uconvert(NoUnits, 1.0u"μm/m")
 1.0e-6
 
-julia> uconvert(Unitful.NoUnits, 1.0u"m")
+julia> uconvert(NoUnits, 1.0u"m")
 ERROR: DimensionError:  and m are not dimensionally compatible.
+```
+
+```@docs
+Unitful.NoUnits
 ```
 
 You can also directly convert to a subtype of `Real` or `Complex`:
@@ -299,8 +303,8 @@ For multiplication and division, note that powers-of-ten prefixes are significan
 in unit cancellation. For instance, `mV/V` is not simplified, although `V/V` is.
 Also, `N*m/J` is not simplified: there is currently no logic to decide
 whether or not units on a dimensionless quantity seem "intentional" or not.
-It is however possible to cancel units manually, by passing the dimensionless
-quantity to the [`NoUnits`](@ref) constructor. This takes into account different SI-prefixes:
+It is however possible to cancel units manually, by converting the dimensionless
+quantity to the [`NoUnits`](@ref) unit. This takes into account different SI-prefixes:
 ```jldoctest
 julia> using Unitful
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -95,6 +95,17 @@ struct FreeUnits{N,D,A} <: Units{N,D,A} end
 FreeUnits{N,D}() where {N,D} = FreeUnits{N,D,nothing}()
 FreeUnits(::Units{N,D,A}) where {N,D,A} = FreeUnits{N,D,A}()
 
+"""
+    NoUnits
+An object that represents "no units", i.e., the units of a unitless number. The type of
+the object is `Unitful.FreeUnits{(), NoDims}`. It is displayed as an empty string.
+
+Example:
+```jldoctest
+julia> unit(1.0) == NoUnits
+true
+```
+"""
 const NoUnits = FreeUnits{(), NoDims}()
 (y::FreeUnits)(x) = uconvert(y,x)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -112,9 +112,8 @@ true
 
 """
     unit(x::Number)
-Returns a `Unitful.FreeUnits{(), NoDims}` object to indicate that ordinary
-numbers have no units. This is a singleton, which we export as `NoUnits`.
-The unit is displayed as an empty string.
+Returns the [`NoUnits`](@ref) object to indicate that ordinary numbers have no units. The
+unit is displayed as an empty string.
 
 Examples:
 


### PR DESCRIPTION
This fixes a warning during the documentation build, because there was a link to `NoUnits` in the manual but no docstring.

* The docstring is added to the manual the first time that `NoUnits` is mentioned.
* `Unitful.NoUnits` in doctests is replaced by `NoUnits`, because it is exported.
* “the `NoUnits` constructor” is replaced by “the `NoUnits` unit”, because `NoUnits` isn’t a type.