### PR TITLE
Compact number printing in tables in the manual

### DIFF
--- a/docs/src/logarithm.md
+++ b/docs/src/logarithm.md
@@ -233,7 +233,7 @@ Mathematical operations are forwarded to the logarithmic part, so that for examp
 for convenience, though the association is understood (e.g. `s^-1*(3dBm) == (3dBm)/s`).
 
 The behavior of multiplication is summarized in the following table, with entries marked by
-† indicate prohibited operations. This table is populated automatically whenever the docs
+† indicating prohibited operations. This table is populated automatically whenever the docs
 are built.
 
 ```@eval

--- a/docs/src/logarithm.md
+++ b/docs/src/logarithm.md
@@ -244,7 +244,7 @@ quantities = uparse.(head)
 tab = fill("", length(head), length(head))
 for col = eachindex(head), row = 1:col
     try
-        tab[row, col] = string(quantities[row] * quantities[col])
+        tab[row, col] = sprint(show, quantities[row] * quantities[col], context = :compact => true)
     catch
         if quantities[row] === u"1/Hz" && quantities[col] === u"3dB"
             tab[row, col] = "† ‡"
@@ -339,7 +339,7 @@ quantities = uparse.(head)
 tab = fill("", length(head), length(head))
 for col = eachindex(head), row = 1:col
     try
-        tab[row, col] = string(quantities[row] + quantities[col])
+        tab[row, col] = sprint(show, quantities[row] + quantities[col], context = :compact => true)
     catch
         tab[row, col] = "†"
     end

--- a/docs/src/logarithm.md
+++ b/docs/src/logarithm.md
@@ -233,8 +233,7 @@ Mathematical operations are forwarded to the logarithmic part, so that for examp
 for convenience, though the association is understood (e.g. `s^-1*(3dBm) == (3dBm)/s`).
 
 The behavior of multiplication is summarized in the following table, with entries marked by
-† indicating prohibited operations. This table is populated automatically whenever the docs
-are built.
+† indicating prohibited operations.
 
 ```@eval
 using Latexify, Unitful
@@ -328,8 +327,7 @@ julia> 20u"dBm" + @dB 1u"W"/u"W"
 i.e. `1.1 W`.
 
 Rules for addition are summarized in the following table, with entries marked by †
-indicating prohibited operations. This table is populated automatically whenever the docs
-are built.
+indicating prohibited operations.
 
 ```@eval
 using Latexify, Unitful


### PR DESCRIPTION
The table of multiplication rules for logarithmic quantities in the manual is too wide (note the scrollbar at the bottom) due to some very long numbers: 
![Screenshot_20230217_104337](https://user-images.githubusercontent.com/42280794/219702137-cee16b7b-5a64-4147-b39e-6948ca3d9974.png)
This PR uses the shorter printing (`:compact => true`) for the numbers:
![Screenshot_20230217_161120](https://user-images.githubusercontent.com/42280794/219702820-6bc88a5f-de80-4b95-bb39-99c6a9d3b404.png)
This is changed in the addition rules table as well.

Other changes:
* Grammar corrected (“indicate” → “indicating”)
* The remark “This table is populated automatically whenever the docs are built.” is removed. It is not relevant to the user.

