### PR TITLE
Add support for `tanpi`

### DIFF
--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -207,7 +207,7 @@ sqrt(x::AbstractQuantity) = Quantity(sqrt(x.val), sqrt(unit(x)))
 cbrt(x::AbstractQuantity) = Quantity(cbrt(x.val), cbrt(unit(x)))
 
 for _y in (:sin, :cos, :tan, :asin, :acos, :atan, :sinh, :cosh, :tanh, :asinh, :acosh, :atanh,
-           :sinpi, :cospi, :sinc, :cosc, :cis, :cispi, :sincospi)
+           :sinpi, :cospi, :tanpi, :sinc, :cosc, :cis, :cispi, :sincospi)
     if isdefined(Base, _y)
         @eval Base.$(_y)(x::DimensionlessQuantity) = Base.$(_y)(uconvert(NoUnits, x))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ import Unitful:
     ac,
     mg, g, kg,
     Ra, °F, °C, K,
-    rad, °,
+    rad, mrad, °,
     ms, s, minute, hr, d, yr, Hz,
     J, A, N, mol, V,
     mW, W,
@@ -728,6 +728,11 @@ Base.:*(x::MatNum, y::MatNum) = MatNum(x.mat*y.mat)
         end
         if isdefined(Base, :sincospi)
             @test @inferred(sincospi(rad/2)) === (1.0, 0.0)
+        end
+        if isdefined(Base, :tanpi)
+            @test @inferred(tanpi(1f0rad)) === tanpi(1f0)
+            @test @inferred(tanpi(250mrad)) === tanpi(0.25)
+            @test @inferred(tanpi(-100mm/m)) === tanpi(-1//10)
         end
 
         @test @inferred(atan(m*sqrt(3),1m)) ≈ 60°


### PR DESCRIPTION
Julia 1.10 adds a `tanpi` function. This PR adds support for `tanpi(::DimensionlessQuantity)`.