### PR TITLE
Resolve remaining method ambiguities

### DIFF
--- a/src/logarithm.jl
+++ b/src/logarithm.jl
@@ -277,16 +277,10 @@ function (Base.promote_rule(::Type{Level{L1,S1,T1}}, ::Type{Level{L2,S2,T2}})
     end
 end
 
-function Base.promote_rule(::Type{Level{L,R,S}}, ::Type{Quantity{T,D,U}}) where {L,R,S,T,D,U}
-    return promote_type(S, Quantity{T,D,U})
-end
 function Base.promote_rule(::Type{Quantity{T,D,U}}, ::Type{Level{L,R,S}}) where {L,R,S,T,D,U}
     return promote_type(S, Quantity{T,D,U})
 end
 function Base.promote_rule(::Type{Level{L,R,S}}, ::Type{T}) where {L,R,S,T<:Real}
-    return promote_type(S,T)
-end
-function Base.promote_rule(::Type{T}, ::Type{Level{L,R,S}}) where {L,R,S,T<:Real}
     return promote_type(S,T)
 end
 function (Base.promote_rule(::Type{Gain{L1,S1,T1}}, ::Type{Gain{L2,S2,T2}})

--- a/src/promotion.jl
+++ b/src/promotion.jl
@@ -25,7 +25,7 @@ promote_unit(x::Units, y::Units, z::Units, t::Units...) =
 @inline _promote_unit(x::FreeUnits{N1,D}, y::FreeUnits{N2,D}) where {N1,N2,D} =
     upreferred(dimension(x))
 
-@inline _promote_unit(x::T, y::T) where {T <: ContextUnits} = T()  #ambiguity reasons
+@inline _promote_unit(x::ContextUnits{N,D,P,A}, y::ContextUnits{N,D,P,A}) where {N,D,P,A} = x  #ambiguity reasons
 # same units, but promotion context disagrees
 @inline _promote_unit(x::ContextUnits{N,D,P1,A}, y::ContextUnits{N,D,P2,A}) where {N,D,P1,P2,A} =
     ContextUnits{N,D,promote_unit(P1(), P2()),A}()

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -379,6 +379,10 @@ function round(::Type{T}, x::AbstractQuantity, r::RoundingMode;
     unitless = ustrip(u, x)
     return Quantity{S, dimension(T), typeof(u)}(round(unitless, r; kwargs...))
 end
+round(::Type{T}, x::DimensionlessQuantity; kwargs...) where {S, T <: Quantity{S}} =
+    invoke(round, Tuple{Type{T},AbstractQuantity}, T, x; kwargs...) # for ambiguity resolution
+round(::Type{T}, x::DimensionlessQuantity, r::RoundingMode; kwargs...) where {S, T <: Quantity{S}} =
+    invoke(round, Tuple{Type{T},AbstractQuantity,RoundingMode}, T, x, r; kwargs...) # for ambiguity resolution
 
 # that should actually be fixed in Base ↓
 for (f,r) = ((:trunc, :RoundToZero), (:floor, :RoundDown), (:ceil, :RoundUp))

--- a/src/types.jl
+++ b/src/types.jl
@@ -164,7 +164,7 @@ struct Quantity{T,D,U} <: AbstractQuantity{T,D,U}
 end
 
 # Field-only constructor
-Quantity{<:Any,D,U}(val) where {D,U} = Quantity{typeof(val),D,U}(val)
+Quantity{<:Any,D,U}(val::Number) where {D,U} = Quantity{typeof(val),D,U}(val)
 
 constructorof(::Type{Unitful.Quantity{_,D,U}}) where {_,D,U} =
     Unitful.Quantity{T,D,U} where T
@@ -249,7 +249,7 @@ field, `val::T`, and the log of the ratio `val/S` is taken. This type differs fr
 """
 struct Level{L, S, T<:RealOrRealQuantity} <: LogScaled{L}
     val::T
-    function Level{L,S,T}(x) where {L,S,T}
+    function Level{L,S,T}(x::Number) where {L,S,T}
         S isa ReferenceQuantity || throw(DomainError(S, "Reference quantity must be real."))
         dimension(S) != dimension(x) && throw(DimensionError(S,x))
         return new{L,S,T}(x)
@@ -266,8 +266,8 @@ For example, given a gain of `20dB`, we have `val===20`. This type differs from
 """
 struct Gain{L, S, T<:Real} <: LogScaled{L}
     val::T
+    Gain{L, S, T}(x::Number) where {L,S,T<:Real} = new{L,S,T}(x)
 end
-Unitful.Gain{L, S, T}(x::Unitful.Gain{L, S, T}) where {L,S,T<:Real} = x # for ambiguity resolution
 
 """
     struct MixedUnits{T<:LogScaled, U<:Units}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1049,6 +1049,14 @@ end
     @test round(typeof(1mm), 1.0314m) === 1031mm
     @test round(typeof(1.0mm), 1.0314m) === 1031.0mm
     @test round(typeof(1.0mm), 1.0314m; digits=1) === 1031.4mm
+    @test round(typeof(1.0°), 1.125°) === 1.0°
+    @test round(typeof(1.0°), 1.125°, RoundUp) === 2.0°
+    @test round(typeof(1.0°), 1.125°, digits=1) === 1.1°
+    @test round(typeof(1.0°), 1.125°, RoundUp, digits=1) === 1.2°
+    @test round(typeof(1.0°), 1rad) === 57.0°
+    @test round(typeof(1.0°), 1rad, RoundUp) === 58.0°
+    @test floor(typeof(1.0°), 1.125°) === 1.0°
+    @test floor(typeof(1.0°), 1.125°, digits=1) === 1.1°
     @test round(u"inch", 1.0314m) === 41.0u"inch"
     @test round(Int, u"inch", 1.0314m) === 41u"inch"
     @test round(typeof(1m), 137cm) === 1m

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2148,4 +2148,4 @@ end
 
 using Aqua
 
-Aqua.test_all(Unitful, ambiguities=false, unbound_args=false, piracy=VERSION≥v"1.8")
+Aqua.test_all(Unitful, ambiguities=VERSION≥v"1.1", unbound_args=false, piracy=VERSION≥v"1.8")


### PR DESCRIPTION
On Julia ≥1.1, this resolves all method ambiguities ~~(edit: all method ambiguities _that are found by `Aqua` or `Test.detect_ambiguities`_. #469 is still broken)~~. On Julia 1.0, there are 5 ambiguities remaining.

Closes #604.

Edit 2: this PR now resolves #469 as well.