### PR TITLE
Remove specialized `Base.reim` method

### DIFF
--- a/src/complex.jl
+++ b/src/complex.jl
@@ -21,9 +21,6 @@ Base.widen(::Type{Quantity{T,D,U}}) where {T,D,U} =
 # skip Base.float, Base.real, Base.imag because it is already
 # implemented
 
-Base.reim(z::Quantity{T,D,U}) where {T<:Complex,D,U} =
-    (real(z), imag(z))
-
 # Base.real for types has a general implementation in julia; a faster
 # method could be provided but is not strictly required.
 


### PR DESCRIPTION
The generic implementation in `Base` works (and does exactly the same), so this specialization isn’t needed.