### PR TITLE
Remove redundant CI runs for Julia 1.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
         julia-version:
           - "1.0"
           - "1"
-          - '~1.9.0-0'
           - "nightly"
         os:
           - ubuntu-latest


### PR DESCRIPTION
Since Julia 1.9 has been released, both `"1"` and `'~1.9.0-0'` now refer to 1.9.