### PR TITLE
Improve support for InverseFunctions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 InverseFunctionsUnitfulExt = "InverseFunctions"
 
 [compat]
-Aqua = "0.6"
+Aqua = "0.6.3"
 ConstructionBase = "1"
 InverseFunctions = "0.1"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -5,16 +5,21 @@ version = "1.14.0"
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[weakdeps]
+InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
+
+[extensions]
+InverseFunctionsUnitfulExt = "InverseFunctions"
 
 [compat]
 Aqua = "0.6"
 ConstructionBase = "1"
+InverseFunctions = "0.1"
 julia = "1"
-
-[extensions]
-InverseFunctionsUnitfulExt = "InverseFunctions"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
@@ -25,6 +30,3 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Aqua", "InverseFunctions", "LinearAlgebra", "Test", "Random"]
-
-[weakdeps]
-InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 

--- a/docs/src/manipulations.md
+++ b/docs/src/manipulations.md
@@ -1,6 +1,7 @@
 ```@meta
 DocTestSetup = quote
     using Unitful
+    using InverseFunctions
 end
 ```
 # Manipulating units

--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -71,4 +71,8 @@ include("complex.jl")
 include("pkgdefaults.jl")
 include("dates.jl")
 
+if !isdefined(Base, :get_extension)
+    include("../ext/InverseFunctionsUnitfulExt.jl")
+end
+
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -24,6 +24,13 @@ true
 julia> ustrip(Float64, u"m", 2u"mm") == 0.002
 true
 ```
+
+`ustrip`` supports `InverseFunctions.inverse`:
+
+```jldoctest
+julia> inverse(Base.Fix1(ustrip, u"m"))(5)
+5 m
+```
 """
 @inline ustrip(u::Units, x) = ustrip(uconvert(u, x))
 @inline ustrip(T::Type, u::Units, x) = convert(T, ustrip(u, x))
@@ -73,13 +80,6 @@ julia> a[1] = 3u"m"; b
 2-element reinterpret(Int64, ::Vector{Quantity{Int64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}}):
  3
  2
-```
-
-`ustrip`` supports `InverseFunctions.inverse`:
-
-```jldoctest
-julia> inverse(Base.Fix1(ustrip, u"m"))(5)
-5 m
 ```
 """
 @inline ustrip(A::Array{Q}) where {Q <: Quantity} = reinterpret(numtype(Q), A)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -25,7 +25,7 @@ julia> ustrip(Float64, u"m", 2u"mm") == 0.002
 true
 ```
 
-`ustrip`` supports `InverseFunctions.inverse`:
+`ustrip` supports `InverseFunctions.inverse`:
 
 ```jldoctest
 julia> inverse(Base.Fix1(ustrip, u"m"))(5)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -74,6 +74,13 @@ julia> a[1] = 3u"m"; b
  3
  2
 ```
+
+`ustrip`` supports `InverseFunctions.inverse`:
+
+```jldoctest
+julia> inverse(Base.Fix1(ustrip, u"m"))(5)
+5 m
+```
 """
 @inline ustrip(A::Array{Q}) where {Q <: Quantity} = reinterpret(numtype(Q), A)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2184,4 +2184,4 @@ Aqua.test_stale_deps(Unitful, ignore=[:InverseFunctions])
 # Project.toml seems to get formatted differently on older Julia versions:
 if VERSION ≥ v"1.6"
     Aqua.test_project_toml_formatting(Unitful)
-end 
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2178,6 +2178,4 @@ end
 
 using Aqua
 
-Aqua.test_all(Unitful, ambiguities=VERSION≥v"1.1", unbound_args=false, piracy=VERSION≥v"1.8", stale_deps=false, project_toml_formatting=VERSION≥v"1.6")
-# Workaround for https://github.com/JuliaTesting/Aqua.jl/issues/107:
-Aqua.test_stale_deps(Unitful, ignore=[:InverseFunctions])
+Aqua.test_all(Unitful, ambiguities=VERSION≥v"1.1", unbound_args=false, piracy=VERSION≥v"1.8", project_toml_formatting=VERSION≥v"1.6")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2178,10 +2178,6 @@ end
 
 using Aqua
 
-Aqua.test_all(Unitful, ambiguities=VERSION≥v"1.1", unbound_args=false, piracy=VERSION≥v"1.8", stale_deps=false, project_toml_formatting = false)
+Aqua.test_all(Unitful, ambiguities=VERSION≥v"1.1", unbound_args=false, piracy=VERSION≥v"1.8", stale_deps=false, project_toml_formatting=VERSION≥v"1.6")
 # Workaround for https://github.com/JuliaTesting/Aqua.jl/issues/107:
 Aqua.test_stale_deps(Unitful, ignore=[:InverseFunctions])
-# Project.toml seems to get formatted differently on older Julia versions:
-if VERSION ≥ v"1.6"
-    Aqua.test_project_toml_formatting(Unitful)
-end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,7 +85,7 @@ const colon = Base.:(:)
     @test ConstructionBase.constructorof(typeof(1.0m))(2) === 2m
 end
 
-VERSION >= v"1.9-" && @testset "inverse" begin
+@testset "inverse" begin
     InverseFunctions.test_inverse(Base.Fix1(ustrip, m), 2m)
     InverseFunctions.test_inverse(Base.Fix1(ustrip, m), 2mm)
 end
@@ -2178,4 +2178,10 @@ end
 
 using Aqua
 
-Aqua.test_all(Unitful, ambiguities=VERSION≥v"1.1", unbound_args=false, piracy=VERSION≥v"1.8")
+Aqua.test_all(Unitful, ambiguities=VERSION≥v"1.1", unbound_args=false, piracy=VERSION≥v"1.8", stale_deps=false, project_toml_formatting = false)
+# Workaround for https://github.com/JuliaTesting/Aqua.jl/issues/107:
+Aqua.test_stale_deps(Unitful, ignore=[:InverseFunctions])
+# Project.toml seems to get formatted differently on older Julia versions:
+if VERSION ≥ v"1.6"
+    Aqua.test_project_toml_formatting(Unitful)
+end 


### PR DESCRIPTION
Makes `ustrip` support for `inverse` available on Julia <1.9 as well and adds documentation.