### PR TITLE
Use JuliaInterpreter to parse unitful expressions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,16 +5,21 @@ version = "1.14.0"
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+JuliaInterpreter = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[weakdeps]
+InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
+
+[extensions]
+InverseFunctionsUnitfulExt = "InverseFunctions"
 
 [compat]
 Aqua = "0.6"
 ConstructionBase = "1"
+JuliaInterpreter = "0.9"
 julia = "1"
-
-[extensions]
-InverseFunctionsUnitfulExt = "InverseFunctions"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
@@ -25,6 +30,3 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Aqua", "InverseFunctions", "LinearAlgebra", "Test", "Random"]
-
-[weakdeps]
-InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"

--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -28,6 +28,8 @@ import Random
 
 import ConstructionBase: constructorof
 
+using JuliaInterpreter: JuliaInterpreter
+
 export logunit, unit, absoluteunit, dimension, uconvert, ustrip, upreferred
 export @dimension, @derived_dimension, @refunit, @unit, @affineunit, @u_str
 export Quantity, DimensionlessQuantity, NoUnits, NoDims

--- a/src/user.jl
+++ b/src/user.jl
@@ -659,7 +659,10 @@ julia> uparse("1.0*dB")
 """
 function uparse(str; unit_context=Unitful)
     ex = Meta.parse(str)
-    eval(lookup_units(unit_context, ex))
+    isa(ex, Symbol) && return lookup_units(unit_context, ex)
+    isa(ex, Number) && return lookup_units(unit_context, ex)
+    ex_processed = lookup_units(unit_context, ex)
+    return JuliaInterpreter.finish_and_return!(JuliaInterpreter.Frame(Unitful, ex_processed))
 end
 
 const allowed_funcs = [:*, :/, :^, :sqrt, :√, :+, :-, ://]


### PR DESCRIPTION
Attempt to address #649. JuliaInterpreter pulls in fewer dependencies than Symbolics.