### PR TITLE
Turn ConstructionBase into a weak dependency in Julia ≥1.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,9 +10,11 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [weakdeps]
+ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 
 [extensions]
+ConstructionBaseUnitfulExt = "ConstructionBase"
 InverseFunctionsUnitfulExt = "InverseFunctions"
 
 [compat]
@@ -23,10 +25,11 @@ julia = "1"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "InverseFunctions", "LinearAlgebra", "Test", "Random"]
+test = ["Aqua", "ConstructionBase", "InverseFunctions", "LinearAlgebra", "Test", "Random"]

--- a/ext/ConstructionBaseUnitfulExt.jl
+++ b/ext/ConstructionBaseUnitfulExt.jl
@@ -1,0 +1,8 @@
+module ConstructionBaseUnitfulExt
+using Unitful
+import ConstructionBase: constructorof
+
+constructorof(::Type{Unitful.Quantity{_,D,U}}) where {_,D,U} =
+    Unitful.Quantity{T,D,U} where T
+
+end

--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -26,8 +26,6 @@ import LinearAlgebra: Diagonal, Bidiagonal, Tridiagonal, SymTridiagonal
 import LinearAlgebra: istril, istriu, norm
 import Random
 
-import ConstructionBase: constructorof
-
 export logunit, unit, absoluteunit, dimension, uconvert, ustrip, upreferred
 export @dimension, @derived_dimension, @refunit, @unit, @affineunit, @u_str
 export Quantity, DimensionlessQuantity, NoUnits, NoDims
@@ -72,6 +70,7 @@ include("pkgdefaults.jl")
 include("dates.jl")
 
 if !isdefined(Base, :get_extension)
+    include("../ext/ConstructionBaseUnitfulExt.jl")
     include("../ext/InverseFunctionsUnitfulExt.jl")
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -166,9 +166,6 @@ end
 # Field-only constructor
 Quantity{<:Any,D,U}(val::Number) where {D,U} = Quantity{typeof(val),D,U}(val)
 
-constructorof(::Type{Unitful.Quantity{_,D,U}}) where {_,D,U} =
-    Unitful.Quantity{T,D,U} where T
-
 """
     DimensionlessUnits{U}
 Useful for dispatching on [`Unitful.Units`](@ref) types that have no dimensions.


### PR DESCRIPTION
Just like `InverseFunctions`, `ConstructionBase` is now a weak dependency on Julia ≥ 1.9 and a normal dependency on older Julia versions.