### PR TITLE
Fix typo in method signature

### DIFF
--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -362,7 +362,7 @@ round(x::AbstractQuantity, r::RoundingMode=RoundNearest; kwargs...) =
 round(x::DimensionlessQuantity; kwargs...) = round(uconvert(NoUnits, x); kwargs...)
 round(x::DimensionlessQuantity, r::RoundingMode; kwargs...) =
     round(uconvert(NoUnits, x), r; kwargs...)
-round(::Type{T}, x::AbstractQuantity, r=RoundingMode=RoundNearest;
+round(::Type{T}, x::AbstractQuantity, r::RoundingMode=RoundNearest;
     kwargs...) where {T<:Number} = _dimerr(:round)
 round(::Type{T}, x::DimensionlessQuantity, r::RoundingMode=RoundNearest;
     kwargs...) where {T<:Number} = round(T, uconvert(NoUnits, x), r; kwargs...)


### PR DESCRIPTION
This doesn’t really have a significant effect, it just changes the type of error that’s thrown.