### PR TITLE
Don’t use `@doc(…)` to look up docstrings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Unitful.jl changelog
 
+## v1.16.1 (2023-08-02)
+
+* ![Enhancement:](https://img.shields.io/badge/-enhancement-blue) Replaced occurrences of single-argument `@doc` for duplicating docstrings, which could lead to errors when creating a Docker image with Julia 1.9 and Unitful ([#671](https://github.com/PainterQubits/Unitful.jl/pull/671)).
+
 ## v1.16.0 (2023-08-01)
 
 * ![Feature:](https://img.shields.io/badge/-feature-green) The derived dimension `MolarMass` (`𝐌/𝐍`) is added ([#663](https://github.com/PainterQubits/Unitful.jl/pull/663)).

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Unitful"
 uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
-version = "1.16.0"
+version = "1.16.1"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -302,12 +302,7 @@ const ha = Unitful.FreeUnits{(Unitful.Unit{:Are, 𝐋^2}(2, 1//1),), 𝐋^2}()
 \nThe liter, a metric unit of volume, defined as 1000 cm^3.
 \nDimension: 𝐋^3.
 \nSee Also: [`Unitful.cm`](@ref)."
-@unit L      "L"        Liter       m^3//1000                true
-for p in (:y, :z, :a, :f, :p, :n, :μ, :m, :c, :d,
-    Symbol(""), :da, :h, :k, :M, :G, :T, :P, :E, :Z, :Y)
-    Core.eval(Unitful, :(const $(Symbol(p,:l)) = $(Symbol(p,:L))))
-end
-@doc @doc(L) l
+(@unit(L,    "L",       Liter,      m^3//1000,              true), const l = L)
 for (k,v) in prefixdict
     if k != 0
         sym_L = Symbol(v,:L)
@@ -322,7 +317,7 @@ for (k,v) in prefixdict
 
                     See also: [`Unitful.L`](@ref).
                     """
-        run = quote @doc $docstring $sym_l; @doc $docstring $sym_L end
+        run = quote @doc $docstring ((const $sym_l = $sym_L), $sym_L) end
         eval(run)
     end
 end
@@ -395,8 +390,7 @@ const μ0 = 4π*(1//10)^7*H/m         # exact (but gets promoted to Float64...),
 \nA quantity representing the vacuum permittivity constant, defined as 1 / (μ0 × c^2).
 \nDimension: 𝐈^2 𝐓^4 𝐋^-3 𝐌^-1.
 \nSee also: [`Unitful.μ0`](@ref), [`Unitful.c`](@ref)."
-const ε0 = 1/(μ0*c^2)               # exact, electric constant; changes here may affect
-@doc @doc(ε0) const ϵ0 = ε0         # test of issue 79.
+((const ε0 = 1/(μ0*c^2)), const ϵ0 = ε0) # exact, electric constant; changes here may affect
 "    Unitful.Z0
 \nA quantity representing the impedance of free space, a constant defined as μ0 × c.
 \nDimension: 𝐋^2 𝐌 𝐈^-2 𝐓^-3.
@@ -586,8 +580,7 @@ earth, a unit of acceleration, defined by standard to be exactly 9.806,65 m / s^
 \nThe angstrom, a metric unit of length defined as 1/10 nm.
 \nDimension: [`Unitful.𝐋`](@ref).
 \nSee Also: [`Unitful.nm`](@ref)."
-@unit angstrom  "Å"        Angstrom             (1//10)*nm      false
-@doc @doc(angstrom) const Å = angstrom
+(@unit(angstrom,"Å",       Angstrom,            (1//10)*nm,             false), const Å = angstrom)
 
 # Area
 "    Unitful.ac

--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -302,7 +302,7 @@ const ha = Unitful.FreeUnits{(Unitful.Unit{:Are, 𝐋^2}(2, 1//1),), 𝐋^2}()
 \nThe liter, a metric unit of volume, defined as 1000 cm^3.
 \nDimension: 𝐋^3.
 \nSee Also: [`Unitful.cm`](@ref)."
-(@unit(L,    "L",       Liter,      m^3//1000,              true), const l = L)
+((@unit L    "L"        Liter       m^3//1000               true), const l = L)
 for (k,v) in prefixdict
     if k != 0
         sym_L = Symbol(v,:L)
@@ -580,7 +580,7 @@ earth, a unit of acceleration, defined by standard to be exactly 9.806,65 m / s^
 \nThe angstrom, a metric unit of length defined as 1/10 nm.
 \nDimension: [`Unitful.𝐋`](@ref).
 \nSee Also: [`Unitful.nm`](@ref)."
-(@unit(angstrom,"Å",       Angstrom,            (1//10)*nm,             false), const Å = angstrom)
+((@unit angstrom "Å"       Angstrom             (1//10)*nm              false), const Å = angstrom)
 
 # Area
 "    Unitful.ac

--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -390,7 +390,7 @@ const μ0 = 4π*(1//10)^7*H/m         # exact (but gets promoted to Float64...),
 \nA quantity representing the vacuum permittivity constant, defined as 1 / (μ0 × c^2).
 \nDimension: 𝐈^2 𝐓^4 𝐋^-3 𝐌^-1.
 \nSee also: [`Unitful.μ0`](@ref), [`Unitful.c`](@ref)."
-((const ε0 = 1/(μ0*c^2)), const ϵ0 = ε0) # exact, electric constant; changes here may affect
+((const ε0 = 1/(μ0*c^2)), const ϵ0 = ε0) # exact, electric constant; changes here may affect test of issue 79.
 "    Unitful.Z0
 \nA quantity representing the impedance of free space, a constant defined as μ0 × c.
 \nDimension: 𝐋^2 𝐌 𝐈^-2 𝐓^-3.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2057,10 +2057,21 @@ end
     @test uparse("ɛ0") === uparse("ε0")
     @test @doc(Unitful.ɛ0) == @doc(Unitful.ε0)
     # Julia treats Å (U+00C5) and Å (U+212B) as the same
-    @test Unitful.Å === Unitful.Å === Unitful.angstrom
+    @test Unitful.Å === Unitful.Å
     @test u"Å" === u"Å"
     @test uparse("Å") === uparse("Å")
     @test @doc(Unitful.Å) == @doc(Unitful.Å)
+end
+
+@testset "Units aliases" begin
+    @test Unitful.L === Unitful.l
+    @test Unitful.mL === Unitful.ml
+    @test 1Unitful.L === 1Unitful.l
+    @test 2Unitful.mL === 2Unitful.ml
+    @test Unitful.ϵ0 === Unitful.ε0
+    @test (1//2)Unitful.ϵ0 === (1//2)Unitful.ε0
+    @test Unitful.Å === Unitful.angstrom
+    @test 1.0Unitful.Å === 1.0Unitful.angstrom
 end
 
 module DocUnits
@@ -2076,6 +2087,10 @@ module DocUnits
 end
 
 @testset "Docs" begin
+    @test string(@doc(Unitful.L)) == string(@doc(Unitful.l))
+    @test string(@doc(Unitful.cL)) == string(@doc(Unitful.cl))
+    @test string(@doc(Unitful.ϵ0)) == string(@doc(Unitful.ε0))
+    @test string(@doc(Unitful.Å)) == string(@doc(Unitful.angstrom))
     @test string(@doc DocUnits.𝐃) == "dimension docs\n"
     @test string(@doc DocUnits.dRefFoo) == "refunit docs\n"
     @test string(@doc DocUnits.dFoo) == "unit docs\n"


### PR DESCRIPTION
This also simplifies the definition of prefixed liters (`Unitful.ml` etc.).

Should fix #667.