### PR TITLE
Test on Julia 1.6 and fix tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         julia-version:
           - "1.0"
+          - "1.6"
           - "1"
           - "nightly"
         os:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2198,4 +2198,4 @@ end
 
 using Aqua
 
-Aqua.test_all(Unitful, ambiguities=VERSION≥v"1.1", unbound_args=false, piracy=VERSION≥v"1.8", project_toml_formatting=VERSION≥v"1.6")
+Aqua.test_all(Unitful, ambiguities=VERSION≥v"1.1", unbound_args=false, piracy=VERSION≥v"1.8", project_toml_formatting=VERSION≥v"1.8")


### PR DESCRIPTION
The Project.toml formatting test (from Aqua.jl) fails on Julia 1.6 and 1.7, so this PR changes it to only run on Julia ≥ 1.8.