### PR TITLE
Add `Base.hastypemax` method

### DIFF
--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -502,6 +502,8 @@ Returns a `Quantity` with the same units.
 """
 Rational(x::AbstractQuantity) = Quantity(Rational(x.val), unit(x))
 
+Base.hastypemax(::Type{<:AbstractQuantity{T}}) where {T} = Base.hastypemax(T)
+
 typemin(::Type{<:AbstractQuantity{T,D,U}}) where {T,D,U} = typemin(T)*U()
 typemin(x::AbstractQuantity{T}) where {T} = typemin(T)*unit(x)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1130,6 +1130,8 @@ end
     @test @inferred(imag((3+4im)V)) == 4V
     @test @inferred(conj(3m)) == 3m
     @test @inferred(conj((3+4im)V)) == (3-4im)V
+    @test @inferred(Base.hastypemax(typeof(1.0m))) === Base.hastypemax(typeof(1.0))
+    @test @inferred(Base.hastypemax(typeof(big(1)m))) === Base.hastypemax(typeof(big(1)))
     @test @inferred(typemin(1.0m)) == -Inf*m
     @test @inferred(typemax(typeof(1.0m))) == Inf*m
     @test @inferred(typemin(0x01*m)) == 0x00*m


### PR DESCRIPTION
Since we define `typemax` and `typemin` methods, the generic fallback for `Base.hastypemax` doesn’t work, so we should also define a `Base.hastypemax` method.