### PR TITLE
Use fallback implementation for `min`, `max`

### DIFF
--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -217,39 +217,6 @@ atan(y::AbstractQuantity{T1,D,U1}, x::AbstractQuantity{T2,D,U2}) where {T1,T2,D,
 atan(y::AbstractQuantity{T,D,U}, x::AbstractQuantity{T,D,U}) where {T,D,U} = atan(y.val,x.val)
 atan(y::AbstractQuantity, x::AbstractQuantity) = throw(DimensionError(x,y))
 
-for (f, F) in [(:min, :<), (:max, :>)]
-    @eval @generated function ($f)(x::AbstractQuantity, y::AbstractQuantity)    #TODO
-        xdim = x.parameters[2]
-        ydim = y.parameters[2]
-        if xdim != ydim
-            return :(throw(DimensionError(x,y)))
-        end
-
-        isa(x.parameters[3](), FixedUnits) &&
-            isa(y.parameters[3](), FixedUnits) &&
-            x.parameters[3] !== y.parameters[3] &&
-            error("automatic conversion prohibited.")
-
-        xunits = x.parameters[3].parameters[1]
-        yunits = y.parameters[3].parameters[1]
-
-        factx = mapreduce((x,y)->broadcast(*,x,y), xunits) do x
-            vcat(basefactor(x)...)
-        end
-        facty = mapreduce((x,y)->broadcast(*,x,y), yunits) do x
-            vcat(basefactor(x)...)
-        end
-
-        tensx = mapreduce(tensfactor, +, xunits)
-        tensy = mapreduce(tensfactor, +, yunits)
-
-        convx = *(factx..., (10.0)^tensx)
-        convy = *(facty..., (10.0)^tensy)
-
-        :($($F)(x.val*$convx, y.val*$convy) ? x : y)
-    end
-end
-
 abs(x::AbstractQuantity) = Quantity(abs(x.val), unit(x))
 abs2(x::AbstractQuantity) = Quantity(abs2(x.val), unit(x)*unit(x))
 angle(x::AbstractQuantity{<:Complex}) = angle(x.val)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -636,6 +636,12 @@ Base.:(<=)(x::Issue399, y::Issue399) = x.num <= y.num
         @test_throws ErrorException Issue399(1)m < Issue399(2)m
         @test_throws ErrorException Issue399(1)m == Issue399(1)m
         @test @inferred(Issue399(1)m <= Issue399(2)m)
+
+        # check NaN handling in min, max (consistent with isless)
+        @test isequal(min(NaN * u"m", 1.0u"m"), 1.0u"m")
+        @test isequal(min(1.0u"m", NaN * u"m"), 1.0u"m")
+        @test isequal(max(NaN * u"m", 1.0u"m"), NaN * u"m")
+        @test isequal(max(1.0u"m", NaN * u"m"), NaN * u"m")
     end
     @testset "> Addition and subtraction" begin
         @test @inferred(+(1A)) == 1A                    # Unary addition

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -231,6 +231,21 @@ end
             @test_or_throws ArgumentError is_finite_nonzero(uconvert(u"Tb^11", 1u"ab^11"))
             @test_or_throws ArgumentError is_finite_nonzero(uconvert(u"b^11 * eV", 1u"m^22 * J"))
             @test_or_throws ArgumentError is_finite_nonzero(uconvert(u"m^22 * J", 1u"b^11 * eV"))
+
+            # min/max had code doing the equivalent of uconvert, and suffering
+            # from similar problems as issue 647 (see above)
+            @test_or_throws ArgumentError max(1u"Ym^18", 1u"Em^18") === 1u"Ym^18"
+            @test_or_throws ArgumentError max(1u"Em^18", 1u"Ym^18") === 1u"Ym^18"
+            @test_or_throws ArgumentError min(1u"Ym^18", 1u"Em^18") === 1u"Em^18"
+            @test_or_throws ArgumentError min(1u"Em^18", 1u"Ym^18") === 1u"Em^18"
+            @test_or_throws ArgumentError minmax(1u"Ym^18", 1u"Em^18") ===
+                (1u"Em^18", 1u"Em^18")
+            @test_or_throws ArgumentError max(1u"fb^8", 1u"ab^8") === 1u"fb^8"
+            @test_or_throws ArgumentError max(1u"ab^8", 1u"fb^8") === 1u"fb^8"
+            @test_or_throws ArgumentError min(1u"fb^8", 1u"ab^8") === 1u"ab^8"
+            @test_or_throws ArgumentError min(1u"ab^8", 1u"fb^8") === 1u"ab^8"
+            @test_or_throws ArgumentError minmax(1u"fb^8", 1u"ab^8") ===
+                (1u"ab^8", 1u"fb^8")
         end
     end
 end


### PR DESCRIPTION
`min` and `max` are currently explicitly defined for `AbstractQuantity` arguments and have their own separate re-implementation of `uconvert` for some reason. However, it turns out that this is unnecessary since the standard fallback implementations of `min` and `max` already work perfectly fine for `AbstractQuantity`, because comparison is also defined. Thus, this simply removes these extra method definitions, which, as a bonus, also provides all of the error checking added in #648 to `min` and `max` as well.