### PR TITLE
Import REPL stdlib in test suite

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,8 +28,9 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "ConstructionBase", "InverseFunctions", "LinearAlgebra", "Test", "Random"]
+test = ["Aqua", "ConstructionBase", "InverseFunctions", "LinearAlgebra", "Test", "Random", "REPL"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2137,6 +2137,8 @@ module DocUnits
     @unit dFoo "dFoo" DFoo 1*dRefFoo*u"m" true true
 end
 
+using REPL # This is necessary to make `@doc` work correctly
+
 @testset "Docs" begin
     @test string(@doc(Unitful.L)) == string(@doc(Unitful.l))
     @test string(@doc(Unitful.cL)) == string(@doc(Unitful.cl))


### PR DESCRIPTION
This fixes the test failures on Julia master: Since `REPL` was removed from the sysimg (https://github.com/JuliaLang/julia/pull/51399), it is necessary to import it to make `@doc` work correctly (even though `@doc` is exported by `Base`).