### PR TITLE
README: remove link to "latest" documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/PainterQubits/Unitful.jl/badge.svg?branch=master)](https://coveralls.io/github/PainterQubits/Unitful.jl?branch=master)
 [![codecov.io](https://codecov.io/github/PainterQubits/Unitful.jl/coverage.svg?branch=master)](https://codecov.io/github/PainterQubits/Unitful.jl?branch=master)
 
-[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://PainterQubits.github.io/Unitful.jl/stable)
-[![](https://img.shields.io/badge/docs-dev-blue.svg)](https://PainterQubits.github.io/Unitful.jl/dev)
+
 
 # Unitful.jl
 
@@ -13,7 +12,7 @@ cases eliminate the run-time penalty of units. There should be facilities
 for dimensional analysis. All of this should integrate easily with the usual
 mathematical operations and collections that are found in Julia base.
 
-### Documentation: [Stable](http://PainterQubits.github.io/Unitful.jl/stable)
+### Documentation: [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://PainterQubits.github.io/Unitful.jl/stable) [![](https://img.shields.io/badge/docs-dev-blue.svg)](https://PainterQubits.github.io/Unitful.jl/dev)
 
 
 ## Other packages in the Unitful family

--- a/README.md
+++ b/README.md
@@ -13,10 +13,8 @@ cases eliminate the run-time penalty of units. There should be facilities
 for dimensional analysis. All of this should integrate easily with the usual
 mathematical operations and collections that are found in Julia base.
 
-## Documentation
+### Documentation: [Stable](http://PainterQubits.github.io/Unitful.jl/stable)
 
-[Stable](http://PainterQubits.github.io/Unitful.jl/stable) and
-[latest](https://PainterQubits.github.io/Unitful.jl/latest) versions available.
 
 ## Other packages in the Unitful family
 


### PR DESCRIPTION
"Latest" link pointed to some obsolete and presumably abandoned version of the documentation