### PR TITLE
Allow two argument version of `nextfloat` and `prevfloat`

### DIFF
--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -436,8 +436,10 @@ Returns the sign bit of the underlying numeric value of `x`.
 """
 signbit(x::AbstractQuantity) = signbit(x.val)
 
-prevfloat(x::AbstractQuantity{T}) where {T <: AbstractFloat} = Quantity(prevfloat(x.val), unit(x))
-nextfloat(x::AbstractQuantity{T}) where {T <: AbstractFloat} = Quantity(nextfloat(x.val), unit(x))
+prevfloat(x::AbstractQuantity{T}, d::Integer) where {T <: AbstractFloat} = Quantity(prevfloat(x.val, d), unit(x))
+prevfloat(x::AbstractQuantity{T}) where {T <: AbstractFloat} = prevfloat(x, 1)
+nextfloat(x::AbstractQuantity{T}, d::Integer) where {T <: AbstractFloat} = Quantity(nextfloat(x.val, d), unit(x))
+nextfloat(x::AbstractQuantity{T}) where {T <: AbstractFloat} = nextfloat(x, 1)
 
 function frexp(x::AbstractQuantity{T}) where {T <: AbstractFloat}
     a,b = frexp(x.val)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -842,7 +842,11 @@ Base.:(<=)(x::Issue399, y::Issue399) = x.num <= y.num
         @test !isapprox(1.0u"m",5)
         @test frexp(1.5m) == (0.75m, 1.0)
         @test unit(nextfloat(0.0m)) == m
+        @test unit(nextfloat(0.0m, 4)) == m
+        @test ustrip(nextfloat(0.0m, 4)) == nextfloat(0.0, 4)
         @test unit(prevfloat(0.0m)) == m
+        @test unit(prevfloat(0.0m, 4)) == m
+        @test ustrip(prevfloat(0.0m, 4)) == prevfloat(0.0, 4)
 
         # NaN behavior
         @test NaN*m != NaN*m


### PR DESCRIPTION
The second argument is an integer `n` and the function gives the `n`th next/previous float. Here is the function definition for `Floats` in Julia: https://github.com/JuliaLang/julia/blob/fae6b7859b493160a290e79cf00ca1549bc9b6c7/base/float.jl#L857C1-L857C1