### PR TITLE
Add `ustrip()` support to `Base.TwicePrecision`

### DIFF
--- a/src/range.jl
+++ b/src/range.jl
@@ -115,6 +115,7 @@ _colon(::Any, ::Any, start::T, step, stop::T) where {T} =
 *(x::Base.TwicePrecision, y::Units) = Base.TwicePrecision(x.hi*y, x.lo*y)
 *(x::Base.TwicePrecision, y::Quantity) = (x * ustrip(y)) * unit(y)
 uconvert(y, x::Base.TwicePrecision) = Base.TwicePrecision(uconvert(y, x.hi), uconvert(y, x.lo))
+ustrip(x::Base.TwicePrecision) = Base.TwicePrecision(ustrip(x.hi), ustrip(x.lo))
 @inline upreferred(x::Base.TwicePrecision{T}) where T<:Number = x
 @inline upreferred(x::Base.TwicePrecision{T}) where T<:AbstractQuantity =
     uconvert(upreferred(unit(x)), x)


### PR DESCRIPTION
Fixes https://github.com/PainterQubits/Unitful.jl/issues/709