### PR TITLE
Fix `ustrip` broadcasting when range step has different unit than eltype

### DIFF
--- a/src/range.jl
+++ b/src/range.jl
@@ -160,16 +160,16 @@ broadcasted(::DefaultArrayStyle{1}, ::typeof(*), x::Ref{<:Units}, r::AbstractRan
 broadcasted(::DefaultArrayStyle{1}, x::BCAST_PROPAGATE_CALLS, r::StepRangeLen) = StepRangeLen{typeof(x(zero(eltype(r))))}(x(r.ref), x(r.step), r.len, r.offset)
 function broadcasted(::DefaultArrayStyle{1}, x::BCAST_PROPAGATE_CALLS, r::StepRange)
     start = x(r.start)
-    au_to = isa(start, AbstractQuantity) ? absoluteunit(start) : NoUnits # absoluteunit doesn’t work on non-quantities
+    au_to = absoluteunit(unit(start))
     step = uconvert(au_to, r.step)
     if Base.ArithmeticStyle(start) == Base.ArithmeticRounds() || Base.ArithmeticStyle(step) == Base.ArithmeticRounds()
-        au_from = isa(start, AbstractQuantity) ? absoluteunit(r.start) : NoUnits # absoluteunit doesn’t work on non-quantities
+        au_from = absoluteunit(unit(r.start))
         astart = ustrip(au_from, r.start)
         astop = ustrip(au_from, r.stop)
         len = length(r)
         offset = _offset_for_steprangelen(astart, astop, len)
         nb = ndigits(max(offset-1, len-offset), base=2, pad=0)
-        T = promote_type(numtype(start), numtype(step))
+        T = promote_type(typeof(start/unit(start)), typeof(step/unit(step)))
         unitless_range = Base.steprangelen_hp(T, ustrip(au_to, r[offset]), ustrip(au_to, step), nb, len, offset)
         return unitless_range * unit(start)
     else

--- a/src/range.jl
+++ b/src/range.jl
@@ -168,7 +168,7 @@ function broadcasted(::DefaultArrayStyle{1}, x::BCAST_PROPAGATE_CALLS, r::StepRa
         astop = ustrip(au_from, r.stop)
         len = length(r)
         offset = _offset_for_steprangelen(astart, astop, len)
-        nb = Base.top_set_bit(max(offset-1, len-offset))
+        nb = ndigits(max(offset-1, len-offset), base=2, pad=0)
         T = promote_type(numtype(start), numtype(step))
         unitless_range = Base.steprangelen_hp(T, ustrip(au_to, r[offset]), ustrip(au_to, step), nb, len, offset)
         return unitless_range * unit(start)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ import Unitful:
     Ra, °F, °C, K,
     rad, mrad, °,
     ms, s, minute, hr, d, yr, Hz,
-    J, A, N, mol, V,
+    J, A, N, mol, V, mJ, eV,
     mW, W,
     dB, dB_rp, dB_p, dBm, dBV, dBSPL, Decibel,
     Np, Np_rp, Np_p, Neper,
@@ -1325,14 +1325,29 @@ end
 
             @test @inferred((1:2:5) .* cm .|> mm) === 10mm:20mm:50mm
             @test mm.((1:2:5) .* cm) === 10mm:20mm:50mm
+            @test @inferred(StepRange(1cm,1mm,2cm) .|> km) === (1//100_000)km:(1//1_000_000)km:(2//100_000)km
+            @test @inferred((1eV:1eV:5eV) .|> mJ) === mJ(1eV):mJ(1eV):mJ(5eV)
+
             @test @inferred((1:2:5) .* km .|> upreferred) === 1000m:2000m:5000m
             @test @inferred((1:2:5)km .|> upreferred) === 1000m:2000m:5000m
             @test @inferred((1:2:5) .|> upreferred) === 1:2:5
             @test @inferred((1.0:2.0:5.0) .* km .|> upreferred) === 1000.0m:2000.0m:5000.0m
             @test @inferred((1.0:2.0:5.0)km .|> upreferred) === 1000.0m:2000.0m:5000.0m
             @test @inferred((1.0:2.0:5.0) .|> upreferred) === 1.0:2.0:5.0
+            @test @inferred(StepRange(1cm,1mm,2cm) .|> upreferred) === (1//100)m:(1//1000)m:(2//100)m
+            @test @inferred((1eV:1eV:5eV) .|> upreferred) === upreferred(1eV):upreferred(1eV):upreferred(5eV)
+
             @test @inferred((1:2:5) .* cm .|> mm .|> ustrip) === 10:20:50
             @test @inferred((1f0:2f0:5f0) .* cm .|> mm .|> ustrip) === 10f0:20f0:50f0
+            @test @inferred(StepRange{typeof(1m),typeof(1cm)}(1m,1cm,2m) .|> ustrip) === 1:1//100:2
+            @test @inferred(StepRangeLen{typeof(1f0m)}(1.0m, 1.0cm, 101) .|> ustrip) === StepRangeLen{Float32}(1.0, 0.01, 101)
+            @test @inferred(StepRangeLen{typeof(1.0m)}(Base.TwicePrecision(1.0m), Base.TwicePrecision(1.0cm), 101) .|> ustrip) === StepRangeLen{Float64}(Base.TwicePrecision(1.0), Base.TwicePrecision(0.01), 101)
+            @test @inferred((1:0.1:1.0) .|> ustrip) == 1:0.1:1.0
+            @test @inferred((1m:0.1m:1.0m) .|> ustrip) == 1:0.1:1.0
+            @test @inferred(StepRange{typeof(0m),typeof(1cm)}(1m,1cm,2m) .|> ustrip) === 1:1//100:2
+            @test @inferred(StepRangeLen{typeof(1f0m)}(1.0m, 1.0cm, 101) .|> ustrip) === StepRangeLen{Float32}(1.0, 0.01, 101)
+            @test @inferred(StepRangeLen{typeof(1.0m)}(Base.TwicePrecision(1.0m), Base.TwicePrecision(1.0cm), 101) .|> ustrip) === StepRangeLen{Float64}(Base.TwicePrecision(1.0), Base.TwicePrecision(0.01), 101)
+            @test @inferred(StepRangeLen{typeof(1.0mm)}(Base.TwicePrecision(1.0m), Base.TwicePrecision(1.0cm), 101) .|> ustrip) === 1000.0:10.0:2000.0
         end
         @testset ">> quantities and non-quantities" begin
             @test range(1, step=1m/mm, length=5) == 1:1000:4001

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1348,6 +1348,8 @@ end
             @test @inferred(StepRangeLen{typeof(1f0m)}(1.0m, 1.0cm, 101) .|> ustrip) === StepRangeLen{Float32}(1.0, 0.01, 101)
             @test @inferred(StepRangeLen{typeof(1.0m)}(Base.TwicePrecision(1.0m), Base.TwicePrecision(1.0cm), 101) .|> ustrip) === StepRangeLen{Float64}(Base.TwicePrecision(1.0), Base.TwicePrecision(0.01), 101)
             @test @inferred(StepRangeLen{typeof(1.0mm)}(Base.TwicePrecision(1.0m), Base.TwicePrecision(1.0cm), 101) .|> ustrip) === 1000.0:10.0:2000.0
+            @test ustrip.(1:0.1:1.0) == 1:0.1:1.0
+            @test ustrip.(1m:0.1m:1.0m) == 1:0.1:1.0
         end
         @testset ">> quantities and non-quantities" begin
             @test range(1, step=1m/mm, length=5) == 1:1000:4001
@@ -1414,10 +1416,6 @@ end
                 @test eltype(range(stop=1mm/m, step=1, length=5)) == typeof(1mm/m)
                 @test_throws ArgumentError range(step=1m, length=5)
             end
-        end
-        @testset ">> broadcast ustrip" begin
-            @test ustrip.(1:0.1:1.0) == 1:0.1:1.0
-            @test ustrip.(1m:0.1m:1.0m) == 1:0.1:1.0
         end
     end
     @testset "> Arrays" begin


### PR DESCRIPTION
Fixes #712.

This PR also changes the return type when broadcasting over a `StepRange` and the conversion factor is a floating-point number: in this case, a `StepRangeLen` is returned (instead of a `StepRange`) because it is the better choice for floating-point numbers.