### PR TITLE
Fix codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,10 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
-      - uses: julia-actions/julia-uploadcodecov@v0.1
-        continue-on-error: true
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v3
+        with:
+          files: lcov.info
       - uses: julia-actions/julia-uploadcoveralls@v0.1
         continue-on-error: true
 


### PR DESCRIPTION
This uses the `codecov/codecov-action` action for uploading to codecov instead of the deprecated `julia-actions/julia-uploadcodecov`. Hopefully, this fixes the codecov upload that seems to have broken recently.