### PR TITLE
Make the `isapprox` implementation closer to the LinearAlgebra implementation

### DIFF
--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -266,7 +266,7 @@ function isapprox(
     x::AbstractArray{<:AbstractQuantity{T1,D,U1}},
     y::AbstractArray{<:AbstractQuantity{T2,D,U2}};
     atol=zero(Quantity{real(T1),D,U1}),
-    rtol::Real=Base.rtoldefault(T1,T2,!iszero(atol)),
+    rtol::Real=Base.rtoldefault(T1,T2,atol>zero(atol)),
     nans::Bool=false,
     norm::Function=norm,
 ) where {T1,D,U1,T2,U2}

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -275,7 +275,7 @@ function isapprox(
         return iszero(rtol) ? d <= atol : d <= max(atol, rtol*max(norm(x), norm(y)))
     else
         # Fall back to a component-wise approximate comparison
-        return mapreduce((a, b) -> isapprox(a, b; rtol=rtol, atol=atol, nans=nans), &, x, y)
+        return all(ab -> isapprox(ab[1], ab[2]; rtol=rtol, atol=atol, nans=nans), zip(x, y))
     end
 end
 

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -265,17 +265,17 @@ isapprox(x::Number, y::AbstractQuantity; kwargs...) = isapprox(y, x; kwargs...)
 function isapprox(
     x::AbstractArray{<:AbstractQuantity{T1,D,U1}},
     y::AbstractArray{<:AbstractQuantity{T2,D,U2}};
-    rtol::Real=Base.rtoldefault(T1,T2,0),
     atol=zero(Quantity{real(T1),D,U1}),
+    rtol::Real=Base.rtoldefault(T1,T2,ustrip(atol)),
+    nans::Bool=false,
     norm::Function=norm,
 ) where {T1,D,U1,T2,U2}
-
     d = norm(x - y)
     if isfinite(d)
-        return d <= atol + rtol*max(norm(x), norm(y))
+        return iszero(rtol) ? d <= atol : d <= max(atol, rtol*max(norm(x), norm(y)))
     else
         # Fall back to a component-wise approximate comparison
-        return all(ab -> isapprox(ab[1], ab[2]; rtol=rtol, atol=atol), zip(x, y))
+        return all(ab -> isapprox(ab[1], ab[2]; rtol=rtol, atol=atol, nans=nans), zip(x, y))
     end
 end
 

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -275,7 +275,7 @@ function isapprox(
         return iszero(rtol) ? d <= atol : d <= max(atol, rtol*max(norm(x), norm(y)))
     else
         # Fall back to a component-wise approximate comparison
-        return all(ab -> isapprox(ab[1], ab[2]; rtol=rtol, atol=atol, nans=nans), zip(x, y))
+        return mapreduce((a, b) -> isapprox(a, b; rtol=rtol, atol=atol, nans=nans), &, x, y)
     end
 end
 

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -266,7 +266,7 @@ function isapprox(
     x::AbstractArray{<:AbstractQuantity{T1,D,U1}},
     y::AbstractArray{<:AbstractQuantity{T2,D,U2}};
     atol=zero(Quantity{real(T1),D,U1}),
-    rtol::Real=Base.rtoldefault(T1,T2,ustrip(atol)),
+    rtol::Real=Base.rtoldefault(T1,T2,!iszero(atol)),
     nans::Bool=false,
     norm::Function=norm,
 ) where {T1,D,U1,T2,U2}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1499,6 +1499,10 @@ end
             @test isapprox([1cm, 200cm], [0.01m, 2.0m])
             @test !isapprox([1.0], [1.0m])
             @test !isapprox([1.0m], [1.0])
+            @test isapprox([1.0m, NaN*m], [nextfloat(1.0)*m, NaN*m], nans=true)
+            @test !isapprox([1.0m, NaN*m], [nextfloat(1.0)*m, NaN*m], nans=false)
+            @test !isapprox([1.0m, 2.0m], [1.1m, 2.2m], rtol=0.05, atol=0.2m)
+            @test !isapprox([1.0m], [nextfloat(1.0)*m], atol=eps(0.1)*m)
         end
         @testset ">> Unit stripping" begin
             @test @inferred(ustrip([1u"m", 2u"m"])) == [1,2]


### PR DESCRIPTION
The Unitful implementation of `isapprox(::AbstractArray, ::AbstractArray)` function has some differences compared to the LinearAlgebra implementation.
Link: https://github.com/JuliaLang/julia/blob/master/stdlib/LinearAlgebra/src/generic.jl#L1879-L1891

For example, the comparison in Unitful is:
```julia
d <= atol + rtol*max(norm(x), norm(y))
```
But in LinearAlgebra is:
```julia
iszero(rtol) ? d <= atol : d <= max(atol, rtol*max(norm(x), norm(y)))
```

Another difference is in the use of the `Base.rtoldefault` function. 
The `Base.rtoldefault(x, y, atol)` function returns the default `rtol` only when `atol` is less than or equal to zero, otherwise it returns zero. 
But, in Unitful, the last argument of `Base.rtoldefault` is always zero:
```julia
rtol::Real=Base.rtoldefault(T1,T2,0),
atol=zero(Quantity{real(T1),D,U1})
```
That is, the `rtol` value is always be different than zero, even when `atol > 0`.
Below is the LinearAlgebra implementation for comparison:
```julia
atol::Real=0,
rtol::Real=Base.rtoldefault(promote_leaf_eltypes(x),promote_leaf_eltypes(y),atol)
```
The last difference is that the Unitful doesn't forward the `nans` keyword argument.

These different implementations result in different behaviours:
master branch:
```julia
julia> x = [-48.044483f0, -18.32653f0]
2-element Vector{Float32}:
 -48.044483
 -18.32653

julia> y = [-48.04448f0, -18.326504f0]
2-element Vector{Float32}:
 -48.04448
 -18.326504

julia> isapprox(x, y, atol=1f-5)
false

julia> isapprox(x * u"m", y * u"m", atol=1f-5u"m")
true
```

This PR adjusts the implementation to be closer to the LinearAlgebra implementation:
```julia
julia> x = [-48.044483f0, -18.32653f0]
2-element Vector{Float32}:
 -48.044483
 -18.32653

julia> y = [-48.04448f0, -18.326504f0]
2-element Vector{Float32}:
 -48.04448
 -18.326504

julia> isapprox(x, y, atol=1f-5)
false

julia> isapprox(x * u"m", y * u"m", atol=1f-5u"m")
false
```