### PR TITLE
cis/cispi without explicit uconvert (calls sincos/sincospi)

### DIFF
--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -7,7 +7,7 @@ import Base: min, max, floor, ceil, real, imag, conj
 import Base: complex, widen, reim # handled in complex.jl
 import Base: exp, exp10, exp2, expm1, log, log10, log1p, log2
 import Base: sin, cos, tan, asin, acos, atan, sinh, cosh, tanh, asinh, acosh, atanh,
-             sinpi, cospi, sinc, cosc, cis
+             sinpi, cospi, sinc, cosc, cis, cispi
 import Base: eps, mod, rem, div, fld, cld, divrem, trunc, round, sign, signbit
 import Base: isless, isapprox, isinteger, isreal, isinf, isfinite, isnan
 import Base: copysign, flipsign

--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -7,7 +7,7 @@ import Base: min, max, floor, ceil, real, imag, conj
 import Base: complex, widen, reim # handled in complex.jl
 import Base: exp, exp10, exp2, expm1, log, log10, log1p, log2
 import Base: sin, cos, tan, asin, acos, atan, sinh, cosh, tanh, asinh, acosh, atanh,
-             sinpi, cospi, sinc, cosc, cis, cispi
+             sinpi, cospi, sinc, cosc, cis, sincos
 import Base: eps, mod, rem, div, fld, cld, divrem, trunc, round, sign, signbit
 import Base: isless, isapprox, isinteger, isreal, isinf, isfinite, isnan
 import Base: copysign, flipsign

--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -121,7 +121,6 @@ if isdefined(Base, :sincosd)
     sincosd(x::Quantity{T, NoDims, typeof(°)}) where {T} = sincosd(ustrip(x))
 else
     sincos(x::Quantity{T, NoDims, typeof(°)}) where {T} = (u = ustrip(x); (sind(u), cosd(u)))
-    sincosd(x::Quantity{T, NoDims, typeof(°)}) where {T} = (u = ustrip(x); (sind(u), cosd(u)))
 end
 
 # conversion between degrees and radians

--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -119,6 +119,9 @@ if isdefined(Base, :sincosd)
     import Base: sincosd
     sincos(x::Quantity{T, NoDims, typeof(°)}) where {T} = sincosd(ustrip(x))
     sincosd(x::Quantity{T, NoDims, typeof(°)}) where {T} = sincosd(ustrip(x))
+else
+    sincos(x::Quantity{T, NoDims, typeof(°)}) where {T} = (u = ustrip(x); (sind(u), cosd(u)))
+    sincosd(x::Quantity{T, NoDims, typeof(°)}) where {T} = (u = ustrip(x); (sind(u), cosd(u)))
 end
 
 # conversion between degrees and radians

--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -115,6 +115,11 @@ for (_x,_y) in ((:sin,:sind), (:cos,:cosd), (:tan,:tand),
     @eval ($_x)(x::Quantity{T, NoDims, typeof(°)}) where {T} = ($_y)(ustrip(x))
     @eval ($_y)(x::Quantity{T, NoDims, typeof(°)}) where {T} = ($_y)(ustrip(x))
 end
+if isdefined(Base, :sincosd)
+    import Base: sincosd
+    sincos(x::Quantity{T, NoDims, typeof(°)}) where {T} = sincosd(ustrip(x))
+    sincosd(x::Quantity{T, NoDims, typeof(°)}) where {T} = sincosd(ustrip(x))
+end
 
 # conversion between degrees and radians
 import Base: deg2rad, rad2deg

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -206,11 +206,15 @@ sqrt(x::AbstractQuantity) = Quantity(sqrt(x.val), sqrt(unit(x)))
 cbrt(x::AbstractQuantity) = Quantity(cbrt(x.val), cbrt(unit(x)))
 
 for _y in (:sin, :cos, :tan, :asin, :acos, :atan, :sinh, :cosh, :tanh, :asinh, :acosh, :atanh,
-           :sinpi, :cospi, :tanpi, :sinc, :cosc, :cis, :cispi, :sincospi)
+           :sinpi, :cospi, :tanpi, :sinc, :cosc, :sincospi)
     if isdefined(Base, _y)
         @eval Base.$(_y)(x::DimensionlessQuantity) = Base.$(_y)(uconvert(NoUnits, x))
     end
 end
+cis(x::DimensionlessQuantity{<:Real}) = Complex(reverse(sincos(x))...)
+cis(x::DimensionlessQuantity{<:Complex}) = exp(-imag(x)) * Complex(reverse(sincos(real(x)))...)
+cispi(x::DimensionlessQuantity{<:Real}) = Complex(reverse(sincospi(x))...)
+cispi(x::DimensionlessQuantity{<:Complex}) = exp(-(π*imag(x))) * Complex(reverse(sincospi(real(x)))...)
 
 atan(y::AbstractQuantity{T1,D,U1}, x::AbstractQuantity{T2,D,U2}) where {T1,T2,D,U1,U2} =
     atan(promote(y,x)...)

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -206,15 +206,18 @@ sqrt(x::AbstractQuantity) = Quantity(sqrt(x.val), sqrt(unit(x)))
 cbrt(x::AbstractQuantity) = Quantity(cbrt(x.val), cbrt(unit(x)))
 
 for _y in (:sin, :cos, :tan, :asin, :acos, :atan, :sinh, :cosh, :tanh, :asinh, :acosh, :atanh,
-           :sinpi, :cospi, :tanpi, :sinc, :cosc, :sincospi)
+           :sinpi, :cospi, :tanpi, :sinc, :cosc, :sincos, :sincospi)
     if isdefined(Base, _y)
         @eval Base.$(_y)(x::DimensionlessQuantity) = Base.$(_y)(uconvert(NoUnits, x))
     end
 end
 cis(x::DimensionlessQuantity{<:Real}) = Complex(reverse(sincos(x))...)
 cis(x::DimensionlessQuantity{<:Complex}) = exp(-imag(x)) * Complex(reverse(sincos(real(x)))...)
-cispi(x::DimensionlessQuantity{<:Real}) = Complex(reverse(sincospi(x))...)
-cispi(x::DimensionlessQuantity{<:Complex}) = exp(-(π*imag(x))) * Complex(reverse(sincospi(real(x)))...)
+if isdefined(Base, :cispi)
+    import Base: cispi
+    Base.cispi(x::DimensionlessQuantity{<:Real}) = Complex(reverse(sincospi(x))...)
+    Base.cispi(x::DimensionlessQuantity{<:Complex}) = exp(-(π*imag(x))) * Complex(reverse(sincospi(real(x)))...)
+end
 
 atan(y::AbstractQuantity{T1,D,U1}, x::AbstractQuantity{T2,D,U2}) where {T1,T2,D,U1,U2} =
     atan(promote(y,x)...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -788,6 +788,10 @@ Base.:(<=)(x::Issue399, y::Issue399) = x.num <= y.num
         @test @inferred(asec(1m/1nm)) ≈ π/2
         @test @inferred(acot(2sqrt(3)s/2000ms)) ≈ 30°
 
+        @test @inferred(sincos(250mrad)) === sincos(0.25)
+        @test @inferred(sincos((1+2im)rad)) === sincos(1+2im)
+        @test @inferred(sincos(30°)) === sincosd(30)
+
         @test @inferred(sinh(0.0rad)) == 0.0
         @test @inferred(sinh(1J/N/m) + cosh(1rad)) ≈ MathConstants.e
         @test @inferred(tanh(1m/1μm)) == 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -741,7 +741,8 @@ Base.:(<=)(x::Issue399, y::Issue399) = x.num <= y.num
         @test @inferred(cbrt(m^3)) === m
         @test (2m)^3 === 8*m^3
         @test (8m)^(1//3) === 2.0*m^(1//3)
-        @test @inferred(cis(90°)) ≈ im
+        @test @inferred(cis(90°)) == im
+        @test @inferred(cis((90 - rad2deg(1)*im)°)) ≈ ℯ*im
 
         # Test inferrability of literal powers
         _pow_m3(x) = x^-3
@@ -806,6 +807,7 @@ Base.:(<=)(x::Issue399, y::Issue399) = x.num <= y.num
         @test @inferred(cosc(1ft/3inch)) === 0.25
         if isdefined(Base, :cispi)
             @test @inferred(cispi(rad/2)) === complex(0.0, 1.0)
+            @test @inferred(cispi(rad/2 + im*rad)) ≈ complex(0.0, exp(-π))
         end
         if isdefined(Base, :sincospi)
             @test @inferred(sincospi(rad/2)) === (1.0, 0.0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -790,7 +790,7 @@ Base.:(<=)(x::Issue399, y::Issue399) = x.num <= y.num
 
         @test @inferred(sincos(250mrad)) === sincos(0.25)
         @test @inferred(sincos((1+2im)rad)) === sincos(1+2im)
-        @test @inferred(sincos(30°)) === sincosd(30)
+        @test @inferred(sincos(30°)) === (sind(30), cosd(30))
 
         @test @inferred(sinh(0.0rad)) == 0.0
         @test @inferred(sinh(1J/N/m) + cosh(1rad)) ≈ MathConstants.e

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -828,6 +828,10 @@ Base.:(<=)(x::Issue399, y::Issue399) = x.num <= y.num
         @test @inferred(atan(m*sqrt(3),1e+3mm)) ≈ 60°
         @test_throws DimensionError atan(m*sqrt(3),1e+3s)
         @test @inferred(angle((3im)*V)) ≈ 90°
+
+        if isdefined(Base, :sincosd)
+            @test @inferred(sincosd(5°)) == sincos(5°) == (sind(5°), cosd(5°))
+        end
     end
     @testset "> Exponentials and logarithms" begin
         for f in (exp, exp10, exp2, expm1, log, log10, log1p, log2)


### PR DESCRIPTION
With this PR, `cis` calls `sincos` directly instead of converting to `NoUnits` first. This increases the accuracy if the argument is in degrees, since the lossy unit conversion is avoided (`sincos` calls `sincosd` if the argument is in degrees).

Closes #738.

Edit: Closes #450. Closes #452.