### PR TITLE
Performance improvements for trig functions with `@fastmath`

### DIFF
--- a/src/fastmath.jl
+++ b/src/fastmath.jl
@@ -19,6 +19,7 @@ import Base.FastMath: @fastmath,
     cos_fast,
     sin_fast,
     tan_fast,
+    sincos_fast,
     atan_fast,
     hypot_fast,
     max_fast,
@@ -153,12 +154,9 @@ pow_fast(x::Quantity, y::Rational) = x^y
 sqrt_fast(x::Quantity{T}) where {T <: FloatTypes} =
     Quantity(sqrt_fast(x.val), sqrt(unit(x)))
 
-for f in (:cos, :sin, :tan)
+for f in (:cos, :sin, :tan, :sincos, :cis)
     f_fast = fast_op[f]
-    @eval begin
-        $(f_fast)(x::DimensionlessQuantity{<:Union{Float32,Float64}}) =
-            $(f_fast)(uconvert(NoUnits, x))
-    end
+    @eval $f_fast(x::DimensionlessQuantity) = $f_fast(ustrip(NoUnits, x))
 end
 
 atan_fast(x::Quantity{T,D,U}, y::Quantity{T,D,U}) where {T,D,U} =
@@ -178,9 +176,6 @@ atan_fast(x::Quantity{T,D,U}, y::Quantity{T,D,U}) where {T,D,U} =
         ifelse(y > x, (x,y), (y,x))
 
     # complex numbers
-
-    cis_fast(x::DimensionlessQuantity{T,U}) where {T <: FloatTypes,U} =
-        Complex{T}(cos(x), sin(x))
 
     angle_fast(x::Quantity{T}) where {T <: ComplexTypes} = atan(imag(x), real(x))
 end

--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -122,6 +122,11 @@ if isdefined(Base, :sincosd)
 else
     sincos(x::Quantity{T, NoDims, typeof(°)}) where {T} = (u = ustrip(x); (sind(u), cosd(u)))
 end
+for f in (:cos, :sin, :tan, :sincos, :cis)
+    f_fast = fast_op[f]
+    # Use deg2rad because uncnvert only has Float64 precision
+    @eval $f_fast(x::Quantity{T, NoDims, typeof(°)}) where {T} = $f_fast(deg2rad(x.val))
+end
 
 # conversion between degrees and radians
 import Base: deg2rad, rad2deg

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -212,11 +212,11 @@ for _y in (:sin, :cos, :tan, :asin, :acos, :atan, :sinh, :cosh, :tanh, :asinh, :
     end
 end
 cis(x::DimensionlessQuantity{<:Real}) = Complex(reverse(sincos(x))...)
-cis(x::DimensionlessQuantity{<:Complex}) = exp(-imag(x)) * Complex(reverse(sincos(real(x)))...)
+cis(x::DimensionlessQuantity{<:Complex}) = exp(-imag(x)) * cis(real(x))
 if isdefined(Base, :cispi)
     import Base: cispi
     Base.cispi(x::DimensionlessQuantity{<:Real}) = Complex(reverse(sincospi(x))...)
-    Base.cispi(x::DimensionlessQuantity{<:Complex}) = exp(-(π*imag(x))) * Complex(reverse(sincospi(real(x)))...)
+    Base.cispi(x::DimensionlessQuantity{<:Complex}) = exp(-(π*imag(x))) * cispi(real(x))
 end
 
 atan(y::AbstractQuantity{T1,D,U1}, x::AbstractQuantity{T2,D,U2}) where {T1,T2,D,U1,U2} =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1056,8 +1056,8 @@ end
                 @test isapprox((@eval @fastmath $f($half)), (@eval $f($half)))
                 @test isapprox((@eval @fastmath $f($third)), (@eval $f($third)))
             end
-            @test all(splat(isapprox), Iterators.zip((@eval @fastmath sincos($half)), (@eval sincos($half))))
-            @test all(splat(isapprox), Iterators.zip((@eval @fastmath sincos($third)), (@eval sincos($third))))
+            @test all(x -> isapprox(x...), Iterators.zip((@eval @fastmath sincos($half)), (@eval sincos($half))))
+            @test all(x -> isapprox(x...), Iterators.zip((@eval @fastmath sincos($third)), (@eval sincos($third))))
         end
 
         # complex arithmetic

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1052,10 +1052,12 @@ end
 
             half = 1°/convert(T, 2)
             third = 1°/convert(T, 3)
-            for f in (:cos, :sin, :tan)
+            for f in (:cos, :sin, :tan, :cis)
                 @test isapprox((@eval @fastmath $f($half)), (@eval $f($half)))
                 @test isapprox((@eval @fastmath $f($third)), (@eval $f($third)))
             end
+            @test all(splat(isapprox), Iterators.zip((@eval @fastmath sincos($half)), (@eval sincos($half))))
+            @test all(splat(isapprox), Iterators.zip((@eval @fastmath sincos($third)), (@eval sincos($third))))
         end
 
         # complex arithmetic


### PR DESCRIPTION
#745 improved the accuracy of `cis` for quantities in `°` (degrees), but this unfortunately comes with a performance hit.

Since the `@fastmath` implementation for `cis` (and other trig functions) falls back to the normal implementation for some types, this also impacted the performance of `@fastmath cis(…)`. Since users of `@fastmath` most likely care more about performance and are willing to sacrifice a little numerical accuracy, this PR improves `@fastmath` performance for `sin`, `cos`, `tan`, `sincos`, and `cis`.

Performance with `@fastmath` is now at least as good as before #745 (in some cases better), except when using `BigFloat` with `°`: Before this PR, the conversion from degrees happened with `uconvert`, which for `°` → `rad` only has `Float64` precision. It now uses `deg2rad` for that, which is a bit slower but has `BigFloat` precision. I think that this is fine, since you probably want `BigFloat` precision if you are using `BigFloat`.