### PR TITLE
Preserve the floating-point precision of quantities in `uconvert`

### DIFF
--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -54,7 +54,7 @@ Find the conversion factor from unit `t` to unit `s`, e.g., `convfact(m, cm) == 
             "exponents and/or SI prefixes in units"
         ))
     end
-    return :($(result isa AbstractFloat ? UnitConversionFactor(result) : result))
+    return result isa AbstractFloat ? UnitConversionFactor(result) : result
 end
 
 """

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -47,8 +47,8 @@ Returns 1. (Avoids effort when unnecessary.)
 convfact(s::Units{S}, t::Units{S}) where {S} = 1
 
 """
-    convfact(T::Type, s::Units{S}, t::Units{S})
-Returns a appropriate conversion factor from unit `t` to unit `s` for number type `T`.
+    convfact(T::Type, s::Units, t::Units)
+Returns the appropriate conversion factor from unit `t` to unit `s` for the number type `T`.
 """
 function convfact(::Type{T}, s::Units, t::Units) where {T<:Number}
     cf = convfact(s, t)

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -1,12 +1,14 @@
 """
-    UnitConversionFactor(x::Float64)
+    UnitConversionFactor(x::T) where {T<:AbstractFloat}
 Conversion factor with value `x`.
 
 Used by the [`convfact`](@ref) function in floating point conversion factors
 to preserve the precision of quantities.
 """
-struct UnitConversionFactor <: AbstractIrrational
-    x::Float64
+struct UnitConversionFactor{T<:AbstractFloat} <: AbstractIrrational
+    x::T
+    # the inner constructor necessary for ambiguity resolution
+    UnitConversionFactor(x::T) where {T<:AbstractFloat} = new{T}(x) 
 end
 
 Base.:(==)(a::UnitConversionFactor, b::UnitConversionFactor) = a.x == b.x

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -2,8 +2,8 @@
     UnitConversionFactor(x::T) where {T<:AbstractFloat}
 Conversion factor with value `x`.
 
-Used by the [`convfact`](@ref) function in floating point conversion factors
-to preserve the precision of quantities.
+Used by the [`convfact`](@ref) function to preserve
+the floating-point precision of quantities.
 """
 struct UnitConversionFactor{T<:AbstractFloat} <: AbstractIrrational
     x::T

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -1,5 +1,5 @@
 """
-    UnitConversionFactor(x::T) where {T<:AbstractFloat}
+    UnitConversionFactor(x::AbstractFloat)
 Conversion factor with value `x`.
 
 Used by the [`convfact`](@ref) function to preserve
@@ -11,6 +11,8 @@ struct UnitConversionFactor{T<:AbstractFloat} <: AbstractIrrational
     UnitConversionFactor(x::T) where {T<:AbstractFloat} = new{T}(x) 
 end
 
+Base.:*(a::UnitConversionFactor, b::BigFloat) = a.x * b
+Base.:*(a::BigFloat, b::UnitConversionFactor) = a * b.x
 Base.:(==)(a::UnitConversionFactor, b::UnitConversionFactor) = a.x == b.x
 Base.hash(x::UnitConversionFactor, h::UInt) = hash(x.x, h)
 Base.BigFloat(x::UnitConversionFactor) = BigFloat(x.x)

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -7,6 +7,7 @@ to preserve the precision of quantities.
 """
 struct UnitConversionFactor{T<:AbstractFloat} <: AbstractIrrational
     x::T
+    UnitConversionFactor(x::T) where {T<:AbstractFloat} = new{T}(x) 
 end
 
 Base.:(==)(a::UnitConversionFactor, b::UnitConversionFactor) = a.x == b.x

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -47,6 +47,19 @@ Returns 1. (Avoids effort when unnecessary.)
 convfact(s::Units{S}, t::Units{S}) where {S} = 1
 
 """
+    convfact(T::Type, s::Units{S}, t::Units{S})
+Returns a appropriate conversion factor from unit `t` to unit `s` for number type `T`.
+"""
+function convfact(::Type{T}, s::Units, t::Units) where {T<:Number}
+    cf = convfact(s, t)
+    if cf isa AbstractFloat
+        convert(float(real(T)), cf)
+    else
+        cf
+    end
+end
+
+"""
     uconvert(a::Units, x::Quantity{T,D,U}) where {T,D,U}
 Convert a [`Unitful.Quantity`](@ref) to different units. The conversion will
 fail if the target units `a` have a different dimension than the dimension of
@@ -69,7 +82,7 @@ function uconvert(a::Units, x::Quantity{T,D,U}) where {T,D,U}
     elseif (a isa AffineUnits) || (x isa AffineQuantity)
         return uconvert_affine(a, x)
     else
-        return Quantity(x.val * convfact(a, U()), a)
+        return Quantity(x.val * convfact(T, a, U()), a)
     end
 end
 

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -1,13 +1,12 @@
 """
-    UnitConversionFactor(x::AbstractFloat)
+    UnitConversionFactor(x::Float64)
 Conversion factor with value `x`.
 
 Used by the [`convfact`](@ref) function in floating point conversion factors
 to preserve the precision of quantities.
 """
-struct UnitConversionFactor{T<:AbstractFloat} <: AbstractIrrational
-    x::T
-    UnitConversionFactor(x::T) where {T<:AbstractFloat} = new{T}(x) 
+struct UnitConversionFactor <: AbstractIrrational
+    x::Float64
 end
 
 Base.:(==)(a::UnitConversionFactor, b::UnitConversionFactor) = a.x == b.x

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -228,6 +228,12 @@ end
             # Issue 647:
             @test uconvert(u"kb^1000", 1u"kb^1001 * b^-1") === 1000u"kb^1000"
             @test uconvert(u"kOe^1000", 1u"kOe^1001 * Oe^-1") === 1000u"kOe^1000"
+            # Issue 753:
+            # avoid converting the float type of quantities
+            @test Unitful.numtype(uconvert(m, 100f0cm)) === Float32
+            @test Unitful.numtype(uconvert(cm, (1f0π + im) * m)) === ComplexF32
+            @test Unitful.numtype(uconvert(rad, 360f0°)) === Float32
+            @test Unitful.numtype(uconvert(°, (2f0π + im) * rad)) === ComplexF32
             # Floating point overflow/underflow in uconvert can happen if the
             # conversion factor is large, because uconvert does not cancel
             # common basefactors (or just for really large exponents and/or

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -229,7 +229,7 @@ end
             @test uconvert(u"kb^1000", 1u"kb^1001 * b^-1") === 1000u"kb^1000"
             @test uconvert(u"kOe^1000", 1u"kOe^1001 * Oe^-1") === 1000u"kOe^1000"
             # Issue 753:
-            # avoid converting the float type of quantities
+            # preserve the floating point precision of quantities
             @test Unitful.numtype(uconvert(m, BigFloat(100)cm)) === BigFloat
             @test Unitful.numtype(uconvert(cm, (BigFloat(1)π + im) * m)) === Complex{BigFloat}
             @test Unitful.numtype(uconvert(rad, BigFloat(360)°)) === BigFloat

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -230,10 +230,22 @@ end
             @test uconvert(u"kOe^1000", 1u"kOe^1001 * Oe^-1") === 1000u"kOe^1000"
             # Issue 753:
             # avoid converting the float type of quantities
+            @test Unitful.numtype(uconvert(m, BigFloat(100)cm)) === BigFloat
+            @test Unitful.numtype(uconvert(cm, (BigFloat(1)π + im) * m)) === Complex{BigFloat}
+            @test Unitful.numtype(uconvert(rad, BigFloat(360)°)) === BigFloat
+            @test Unitful.numtype(uconvert(°, (BigFloat(2)π + im) * rad)) === Complex{BigFloat}
+            @test Unitful.numtype(uconvert(m, 100.0cm)) === Float64
+            @test Unitful.numtype(uconvert(cm, (1.0π + im) * m)) === ComplexF64
+            @test Unitful.numtype(uconvert(rad, 360.0°)) === Float64
+            @test Unitful.numtype(uconvert(°, (2.0π + im) * rad)) === ComplexF64
             @test Unitful.numtype(uconvert(m, 100f0cm)) === Float32
             @test Unitful.numtype(uconvert(cm, (1f0π + im) * m)) === ComplexF32
             @test Unitful.numtype(uconvert(rad, 360f0°)) === Float32
             @test Unitful.numtype(uconvert(°, (2f0π + im) * rad)) === ComplexF32
+            @test Unitful.numtype(uconvert(m, Float16(100)cm)) === Float16
+            @test Unitful.numtype(uconvert(cm, (Float16(1)π + im) * m)) === ComplexF16
+            @test Unitful.numtype(uconvert(rad, Float16(360)°)) === Float16
+            @test Unitful.numtype(uconvert(°, (Float16(2)π + im) * rad)) === ComplexF16
             # Floating point overflow/underflow in uconvert can happen if the
             # conversion factor is large, because uconvert does not cancel
             # common basefactors (or just for really large exponents and/or

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -229,7 +229,7 @@ end
             @test uconvert(u"kb^1000", 1u"kb^1001 * b^-1") === 1000u"kb^1000"
             @test uconvert(u"kOe^1000", 1u"kOe^1001 * Oe^-1") === 1000u"kOe^1000"
             # Issue 753:
-            # preserve the floating point precision of quantities
+            # preserve the floating-point precision of quantities
             @test Unitful.numtype(uconvert(m, BigFloat(100)cm)) === BigFloat
             @test Unitful.numtype(uconvert(cm, (BigFloat(1)π + im) * m)) === Complex{BigFloat}
             @test Unitful.numtype(uconvert(rad, BigFloat(360)°)) === BigFloat


### PR DESCRIPTION
master:
```julia
julia> using Unitful

julia> x = 100f0u"cm"
100.0f0 cm

julia> uconvert(u"m", x)
1.0f0 m

julia> x = 45f0u"°"
45.0f0°

julia> uconvert(u"rad", x)
0.7853981633974483 rad
```
PR:
```julia
julia> using Unitful

julia> x = 100f0u"cm"
100.0f0 cm

julia> uconvert(u"m", x)
1.0f0 m

julia> x = 45f0u"°"
45.0f0°

julia> uconvert(u"rad", x)
0.7853982f0 rad
```
<s>The only drawback of this PR is that it now requires the numeric type of the quantity to implement the `real` function.</s>

closes #753 