### PR TITLE
Remove unnecessary lambdas

### DIFF
--- a/src/dimensions.jl
+++ b/src/dimensions.jl
@@ -32,8 +32,8 @@ true
         length(xp) > 0 && append!(b, xp)
     end
 
-    sort!(b, by=x->power(x))
-    sort!(b, by=x->name(x))
+    sort!(b, by=power)
+    sort!(b, by=name)
 
     c = Vector{Dimension}()
     if !isempty(b)

--- a/src/units.jl
+++ b/src/units.jl
@@ -14,9 +14,9 @@
 
     # linunits is an Array containing all of the Unit objects that were
     # found in the type parameters of the FreeUnits objects (a0, a...)
-    sort!(linunits, by=x->power(x))
-    sort!(linunits, by=x->tens(x))
-    sort!(linunits, by=x->name(x))
+    sort!(linunits, by=power)
+    sort!(linunits, by=tens)
+    sort!(linunits, by=name)
 
     # [m,m,cm,cm^2,cm^3,nm,m^4,μs,μs^2,s]
     # reordered as:


### PR DESCRIPTION
Repackaging the function to be used as key is not necessary, and removal results in clearer code.