### PR TITLE
Add a ForwardDiff extension for dimensionless quantities

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,16 +11,19 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [weakdeps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 
 [extensions]
 ConstructionBaseUnitfulExt = "ConstructionBase"
+ForwardDiffExt = "ForwardDiff"
 InverseFunctionsUnitfulExt = "InverseFunctions"
 
 [compat]
 Aqua = "0.8"
 ConstructionBase = "1"
 Dates = "<0.0.1, 1"
+ForwardDiff = "0.10"
 InverseFunctions = "0.1"
 LinearAlgebra = "<0.0.1, 1"
 REPL = "<0.0.1, 1"
@@ -31,6 +34,7 @@ julia = "1"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"

--- a/ext/ForwardDiffExt.jl
+++ b/ext/ForwardDiffExt.jl
@@ -1,0 +1,16 @@
+module ForwardDiffExt
+using Unitful
+using ForwardDiff
+
+function Base.convert(d::Type{ForwardDiff.Dual{T, V, N}}, q::Quantity) where {T, V, N}
+    if dimension(q) == NoDims
+        return d(uconvert(NoUnits, q))
+    else
+        throw(DimensionError(NoUnits,x))
+    end
+end
+# function convert(d::Type{ForwardDiff.Dual{T, V, N}}, q::Quantity{T,NoDims,U}) where {T, V, N, U}
+#     return ForwardDiff.Dual{T, V, N}(uconvert(NoUnits, q))
+# end
+
+end


### PR DESCRIPTION
#682 seemed like low-hanging fruit, so this pull request solves that problem by adding a ForwardDiff extension with a method for `convert` very much like what the MethodError suggests. It is entirely possible that this method is too specific or not specific enough, but this fixes at least that MWE.

I would love to see this extension eventually allow other functionality, e.g. derivatives with respect to dimensional quantities, but this would be a start at least, and facilitates the case where units are only used inside a user-defined function.