### PR TITLE
Add documentation for `logunit`

### DIFF
--- a/docs/src/logarithm.md
+++ b/docs/src/logarithm.md
@@ -432,6 +432,7 @@ displaying logarithmic quantities:
 ## API
 
 ```@docs
+    Unitful.logunit
     Unitful.linear
     Unitful.reflevel
     Unitful.uconvertp

--- a/src/logarithm.jl
+++ b/src/logarithm.jl
@@ -9,6 +9,24 @@ function Base.float(x::Level{L,S}) where {L,S}
     return Level{L,S,typeof(v)}(v)
 end
 big(x::Level{L,S}) where {L,S} = Level{L,S}(big(x.val))
+"""
+    logunit(x::LogScaled)
+    logunit(x::Union{Type{<:LogScaled}, MixedUnits})
+Returns the units associated with a logarithmic `Quantity`, a logarithmically-scaled
+`Quantity` type, or a `Quantity` type with mixed logarithmic / linear scaling.
+
+Examples:
+```jldoctest
+julia> using Unitful
+
+julia> logunit(1*u"dB")
+dB
+
+julia> logunit(u"dB")
+dB
+```
+"""
+function logunit end
 logunit(x::Level{L,S}) where {L,S} = MixedUnits{Level{L,S}}()
 logunit(x::Type{T}) where {L,S,T<:Level{L,S}} = MixedUnits{Level{L,S}}()
 


### PR DESCRIPTION
`logunit` is exported but not documented. This function is useful and documenting it would be beneficial (it recently came up in #582). This PR adds a docstring to `logunit` and adds it to the API documentation in the `logarithm.md` file.