### PR TITLE
Add alias `deg` for `°`

### DIFF
--- a/docs/src/defaultunits.md
+++ b/docs/src/defaultunits.md
@@ -748,6 +748,7 @@ The steradian, a unit of spherical angle. There are 4π sr in a sphere.
 
 ```
 Unitful.°
+Unitful.deg
 ```
 
 The degree, a unit of angle. There are 360° in a circle.

--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -108,6 +108,11 @@ const AbsoluteScaleTemperature = Quantity{T, 𝚯, <:ScalarUnits} where T
 \nThe degree, a unit of angle. There are 360° in a circle.
 \nDimension: [`Unitful.NoDims`](@ref)."
 @unit °       "°"       Degree      pi/180                  false
+"    Unitful.deg
+\nAlias for [`Unitful.°`](@ref).
+\nThe degree, a unit of angle. There are 360 deg in a circle.
+\nDimension: [`Unitful.NoDims`](@ref)."
+const deg = °
 # For numerical accuracy, specific to the degree
 import Base: sind, cosd, tand, secd, cscd, cotd
 for (_x,_y) in ((:sin,:sind), (:cos,:cosd), (:tan,:tand),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -704,6 +704,7 @@ Base.:(<=)(x::Issue399, y::Issue399) = x.num <= y.num
         @test zero(Quantity{Int, 𝐋}) isa Quantity{Int}
         @test @inferred(π/2*u"rad" + 90u"°") ≈ π        # Dimless quantities
         @test @inferred(π/2*u"rad" - 90u"°") ≈ 0        # Dimless quantities
+        @test @inferred(90u"deg" - 90u"°") == 0
         @test_throws DimensionError 1+1m                # Dim mismatched
         @test_throws DimensionError 1-1m
     end
@@ -2290,6 +2291,8 @@ end
     @test 1.0Unitful.Å === 1.0Unitful.angstrom
     @test Unitful.deg === Unitful.°
     @test 2Unitful.° === 2Unitful.deg
+    @test u"deg" === u"°"
+    @test uparse("deg") === uparse("°")
 end
 
 module DocUnits

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ import Unitful:
     ac,
     mg, g, kg,
     Ra, °F, °C, K,
-    rad, mrad, °,
+    rad, mrad, °, deg,
     ms, s, minute, hr, d, yr, Hz,
     J, A, N, mol, V, mJ, eV,
     mW, W,
@@ -2288,6 +2288,8 @@ end
     @test (1//2)Unitful.ϵ0 === (1//2)Unitful.ε0
     @test Unitful.Å === Unitful.angstrom
     @test 1.0Unitful.Å === 1.0Unitful.angstrom
+    @test Unitful.deg === Unitful.°
+    @test 2Unitful.° === 2Unitful.deg
 end
 
 module DocUnits


### PR DESCRIPTION
Reopening #764, but with more tests.

> Some packages are already defining the alias `deg` for `Unitful.°`, so I wanted to trigger some discussion whether it would be feasible to include the alias `deg` for `°` into Unitful.
> If not, feel free to close this PR again.


