### PR TITLE
Update default value of unit_context argument of uparse() method

### DIFF
--- a/src/user.jl
+++ b/src/user.jl
@@ -657,7 +657,7 @@ julia> uparse("1.0*dB")
 1.0 dB
 ```
 """
-function uparse(str; unit_context=Unitful)
+function uparse(str; unit_context=vcat(Unitful, Unitful.unitmodules))
     ex = Meta.parse(str)
     eval(lookup_units(unit_context, ex))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2193,9 +2193,21 @@ end
 
 # Tests for unit extension modules in unit parsing
 @test_throws ArgumentError uparse("foo", unit_context=Unitful)
+@test uparse("foo") === u"foo"  #This work, because default `unit_context` is now `vcat(Unitful, Unitful.unitmodules)`
 @test uparse("foo", unit_context=FooUnits) === u"foo"
 @test uparse("foo", unit_context=[Unitful, FooUnits]) === u"foo"
 @test uparse("foo", unit_context=[FooUnits, Unitful]) === u"foo"
+
+module BazUnits
+    using Unitful
+    @unit baz "baz" MyBaz 1u"m" false
+end
+# Tests unit parsing for unit extension modules in which  Unitful.register(BazUnits) was not done
+@test_throws ArgumentError uparse("baz", unit_context=Unitful)
+@test_throws ArgumentError uparse("baz") #This not work, because BazUnits is not registered to Unitful.unitmodules ( and default `unit_context` argument )
+@test uparse("baz", unit_context=BazUnits) === BazUnits.baz
+@test uparse("baz", unit_context=[Unitful, BazUnits]) === BazUnits.baz
+@test uparse("baz", unit_context=[BazUnits, Unitful]) === BazUnits.baz
 
 # Test for #272
 module OnlyUstrImported


### PR DESCRIPTION
Nevertheless, expanded pkg of Unitful.jl (i.e., UnitfulAtomic.jl) execute Unitful.register(), Unitful.uparse did not recognize these pkgs automatically (due to the defaut value of unit_context arg is Unitful only).
This commit modified this issue.

The following example is picked up from runtest.jl
```julia
# Test that the @u_str macro will not find units in modules which are
# not loaded before the u_str invocation.
module FooUnits
    using Unitful
    @unit foo "foo" MyFoo 1u"m" false
    Unitful.register(FooUnits)
end
# ...
# Test that u_str works when FooUnits is correctly loaded.
module DoesUseFooUnits
    using Unitful, ..FooUnits
    foo() = 1u"foo"
end
@test DoesUseFooUnits.foo() === 1u"foo"

# Tests for unit extension modules in unit parsing
@test_throws ArgumentError uparse("foo", unit_context=Unitful)
################################ Here is the effect of this PR
@test uparse("foo") === u"foo" # This work, because default `unit_context` is now `vcat(Unitful, Unitful.unitmodules)`
################################
@test uparse("foo", unit_context=FooUnits) === u"foo"
@test uparse("foo", unit_context=[Unitful, FooUnits]) === u"foo"
@test uparse("foo", unit_context=[FooUnits, Unitful]) === u"foo"
```