### PR TITLE
add uparse example in index

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -102,6 +102,18 @@ julia> mod(1hr+3minute+5s, 24s)
 17 s
 ```
 
+You can also parse units from a string
+```jldoctest
+julia> unit_str = "km/m^2"
+"kg/m^2"
+
+julia> units = uparse(unit_str)
+kg m⁻²
+
+julia> 100 * units
+100 kg m⁻²
+```
+
 One useful interactive function is being able to convert to preferred (in this case SI) units. 
 
 ```jldoctest


### PR DESCRIPTION
I've added an example for setting units dynamically using `uparse`. This was not easy to find when I was searching for it and it is likely a frequently needed operation. 