### PR TITLE
New attempt at preserving the floating-point precision in `uconvert`

### DIFF
--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -47,8 +47,8 @@ Returns 1. (Avoids effort when unnecessary.)
 convfact(s::Units{S}, t::Units{S}) where {S} = 1
 
 """
-    convfact(T::Type, s::Units{S}, t::Units{S})
-Returns a appropriate conversion factor from unit `t` to unit `s` for number type `T`.
+    convfact(T::Type, s::Units, t::Units)
+Returns the appropriate conversion factor from unit `t` to unit `s` for the number type `T`.
 """
 function convfact(::Type{T}, s::Units, t::Units) where {T<:Number}
     cf = convfact(s, t)

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -47,6 +47,19 @@ Returns 1. (Avoids effort when unnecessary.)
 convfact(s::Units{S}, t::Units{S}) where {S} = 1
 
 """
+    convfact(T::Type, s::Units{S}, t::Units{S})
+Returns a appropriate conversion factor from unit `t` to unit `s` for number type `T`.
+"""
+function convfact(::Type{T}, s::Units, t::Units) where {T<:Number}
+    cf = convfact(s, t)
+    if cf isa AbstractFloat
+        convert(float(real(T)), cf)
+    else
+        cf
+    end
+end
+
+"""
     uconvert(a::Units, x::Quantity{T,D,U}) where {T,D,U}
 Convert a [`Unitful.Quantity`](@ref) to different units. The conversion will
 fail if the target units `a` have a different dimension than the dimension of
@@ -69,7 +82,7 @@ function uconvert(a::Units, x::Quantity{T,D,U}) where {T,D,U}
     elseif (a isa AffineUnits) || (x isa AffineQuantity)
         return uconvert_affine(a, x)
     else
-        return Quantity(x.val * convfact(a, U()), a)
+        return Quantity(x.val * convfact(T, a, U()), a)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -249,11 +249,23 @@ end
             @test uconvert(u"kb^1000", 1u"kb^1001 * b^-1") === 1000u"kb^1000"
             @test uconvert(u"kOe^1000", 1u"kOe^1001 * Oe^-1") === 1000u"kOe^1000"
             # Issue 753:
-            # avoid converting the float type of quantities
+            # preserve the floating point precision of quantities
+            @test Unitful.numtype(uconvert(m, BigFloat(100)cm)) === BigFloat
+            @test Unitful.numtype(uconvert(cm, (BigFloat(1)π + im) * m)) === Complex{BigFloat}
+            @test Unitful.numtype(uconvert(rad, BigFloat(360)°)) === BigFloat
+            @test Unitful.numtype(uconvert(°, (BigFloat(2)π + im) * rad)) === Complex{BigFloat}
+            @test Unitful.numtype(uconvert(m, 100.0cm)) === Float64
+            @test Unitful.numtype(uconvert(cm, (1.0π + im) * m)) === ComplexF64
+            @test Unitful.numtype(uconvert(rad, 360.0°)) === Float64
+            @test Unitful.numtype(uconvert(°, (2.0π + im) * rad)) === ComplexF64
             @test Unitful.numtype(uconvert(m, 100f0cm)) === Float32
             @test Unitful.numtype(uconvert(cm, (1f0π + im) * m)) === ComplexF32
             @test Unitful.numtype(uconvert(rad, 360f0°)) === Float32
             @test Unitful.numtype(uconvert(°, (2f0π + im) * rad)) === ComplexF32
+            @test Unitful.numtype(uconvert(m, Float16(100)cm)) === Float16
+            @test Unitful.numtype(uconvert(cm, (Float16(1)π + im) * m)) === ComplexF16
+            @test Unitful.numtype(uconvert(rad, Float16(360)°)) === Float16
+            @test Unitful.numtype(uconvert(°, (Float16(2)π + im) * rad)) === ComplexF16
             # Floating point overflow/underflow in uconvert can happen if the
             # conversion factor is large, because uconvert does not cancel
             # common basefactors (or just for really large exponents and/or

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -110,6 +110,23 @@ end
         Quantity{Complex{Float64},NoDims,NoUnits}
 end
 
+# A number type for which the results of `real` and `float`
+# are not `<:Real` or `<:AbstractFloat`, respectively
+struct NonReal <: Number
+    num::Int
+end
+Base.:*(x::NonReal, y::Float64) = x.num * y
+Base.real(x::NonReal) = x
+Base.float(x::NonReal) = x
+
+# A number type for which `real` and `float` throw an error
+struct ErrReal <: Number
+    num::Int
+end
+Base.:*(x::ErrReal, y::Float64) = x.num * y
+Base.real(x::ErrReal) = error("real not defined")
+Base.float(x::ErrReal) = error("float not defined")
+
 @testset "Conversion" begin
     @testset "> Unitless ↔ unitful conversion" begin
         @test_throws DimensionError convert(typeof(3m), 1)
@@ -266,6 +283,8 @@ end
             @test Unitful.numtype(uconvert(cm, (Float16(1)π + im) * m)) === ComplexF16
             @test Unitful.numtype(uconvert(rad, Float16(360)°)) === Float16
             @test Unitful.numtype(uconvert(°, (Float16(2)π + im) * rad)) === ComplexF16
+            @test uconvert(rad, NonReal(360)°) == uconvert(rad, 360°)
+            @test uconvert(rad, ErrReal(360)°) == uconvert(rad, 360°)
             # Floating point overflow/underflow in uconvert can happen if the
             # conversion factor is large, because uconvert does not cancel
             # common basefactors (or just for really large exponents and/or

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -248,6 +248,12 @@ end
             # Issue 647:
             @test uconvert(u"kb^1000", 1u"kb^1001 * b^-1") === 1000u"kb^1000"
             @test uconvert(u"kOe^1000", 1u"kOe^1001 * Oe^-1") === 1000u"kOe^1000"
+            # Issue 753:
+            # avoid converting the float type of quantities
+            @test Unitful.numtype(uconvert(m, 100f0cm)) === Float32
+            @test Unitful.numtype(uconvert(cm, (1f0π + im) * m)) === ComplexF32
+            @test Unitful.numtype(uconvert(rad, 360f0°)) === Float32
+            @test Unitful.numtype(uconvert(°, (2f0π + im) * rad)) === ComplexF32
             # Floating point overflow/underflow in uconvert can happen if the
             # conversion factor is large, because uconvert does not cancel
             # common basefactors (or just for really large exponents and/or


### PR DESCRIPTION
Closes #753.

This is a follow-up to #754. It should now work without breaking something.

@eliascarv I took the first commits from #754 and added the `floattype` function.

We should also look at our `promote_rule` methods to see whether we can use this to address #767.