### PR TITLE
Fix `basefactor` calculation in case of rational `tensfactor`

### DIFF
--- a/src/units.jl
+++ b/src/units.jl
@@ -209,6 +209,9 @@ function basefactor(inex, ex, eq, tens, p)
     if isinteger(p)
         p = Integer(p)
     end
+    if isinteger(tens)
+        tens = Integer(tens)
+    end
 
     eq_is_exact = false
     output_ex_float = (10.0^tens * float(ex))^p
@@ -226,7 +229,7 @@ function basefactor(inex, ex, eq, tens, p)
     can_exact2 &= (1/eq_raised < typemax(Int))
     can_exact2 &= isinteger(p)
 
-    if can_exact
+    if can_exact && isinteger(tens)
         if eq_is_exact
             # If we got here then p is an integer.
             # Note that sometimes x^1 can cause an overflow error if x is large because

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -279,8 +279,10 @@ end
             # Issue 780:
             @unit Fr      "Fr"      franklin 1sqrt(dyn)*cm false
             @unit Test780 "Test780" test780  1sqrt(mN)*cm  false
-            @test uconvert(dyn, (1Fr)^2/(1cm)^2) ≈ 1dyn
-            @test uconvert(mN, (1Test780)^2/(1cm)^2) ≈ 1mN
+            @test uconvert(dyn, 1Fr^2/cm^2) ≈ 1dyn
+            @test uconvert(mN, 1Test780^2/cm^2) ≈ 1mN
+            @test_broken uconvert(dyn, 1Fr^2/cm^2) === 1dyn
+            @test_broken uconvert(mN, 1Test780^2/cm^2) === 1mN
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ import Unitful:
     Ra, °F, °C, K,
     rad, mrad, °,
     ms, s, minute, hr, d, yr, Hz,
-    J, A, N, mol, V, mJ, eV,
+    J, A, N, mol, V, mJ, eV, dyn, mN,
     mW, W,
     dB, dB_rp, dB_p, dBm, dBV, dBSPL, Decibel,
     Np, Np_rp, Np_p, Neper,
@@ -276,6 +276,11 @@ end
                 (1u"ab^8", 1u"fb^8")
             # Issue 660:
             @test uconvert(u"Å * ps^-2", 1.0u"kcal*Å^-1*g^-1") ≈ 418.4u"Å * ps^-2"
+            # Issue 780:
+            @unit Fr      "Fr"      franklin 1sqrt(dyn)*cm false
+            @unit Test780 "Test780" test780  1sqrt(mN)*cm  false
+            @test uconvert(dyn, (1Fr)^2/(1cm)^2) ≈ 1dyn
+            @test uconvert(mN, (1Test780)^2/(1cm)^2) ≈ 1mN
         end
     end
 end


### PR DESCRIPTION
This is a minimal fix for #780. The conversion now works, but is still inexact:
```julia
julia> using Unitful: Unitful, dyn, cm, @unit

julia> @unit   Fr      "Fr"        franklin    1sqrt(dyn)*cm   false;

julia> (1Fr)^2/(1cm)^2 |> dyn
1.0000000000000002 dyn
```
Making this exact requires a rewrite of `basefactor(inex, ex, eq, tens, p)`. I hope I will get to it soon.

Closes #780.