### PR TITLE
Remove extra space in definition of `Base` methods

### DIFF
--- a/src/logarithm.jl
+++ b/src/logarithm.jl
@@ -124,25 +124,25 @@ unit(a::MixedUnits{L,U}) where {L,U} = U()
 logunit(a::MixedUnits{L}) where {L} = MixedUnits{L}()
 isunitless(::MixedUnits) = false
 
-Base. *(::MixedUnits, ::MixedUnits) =
+Base.:*(::MixedUnits, ::MixedUnits) =
     throw(ArgumentError("cannot multiply logarithmic units together."))
-Base. /(::MixedUnits{T}, ::MixedUnits{S}) where {T,S} =
+Base.:/(::MixedUnits{T}, ::MixedUnits{S}) where {T,S} =
     throw(ArgumentError("cannot divide logarithmic units except to cancel."))
-Base. /(x::MixedUnits{T}, y::MixedUnits{T}) where {T} = x.units / y.units
+Base.:/(x::MixedUnits{T}, y::MixedUnits{T}) where {T} = x.units / y.units
 
-Base. *(x::MixedUnits{T}, y::Units) where {T} = MixedUnits{T}(x.units * y)
-Base. *(x::Units, y::MixedUnits) = y * x
-Base. /(x::MixedUnits{T}, y::Units) where {T} = MixedUnits{T}(x.units / y)
-Base. /(x::Units, y::MixedUnits) =
+Base.:*(x::MixedUnits{T}, y::Units) where {T} = MixedUnits{T}(x.units * y)
+Base.:*(x::Units, y::MixedUnits) = y * x
+Base.:/(x::MixedUnits{T}, y::Units) where {T} = MixedUnits{T}(x.units / y)
+Base.:/(x::Units, y::MixedUnits) =
     throw(ArgumentError("cannot divide logarithmic units except to cancel."))
 
-Base. *(x::Real, y::MixedUnits{Level{L,S}}) where {L,S} =
+Base.:*(x::Real, y::MixedUnits{Level{L,S}}) where {L,S} =
     (Level{L,S}(fromlog(L,S,x)))*y.units
-Base. *(x::Real, y::MixedUnits{Gain{L,S}}) where {L,S} = (Gain{L,S}(x))*y.units
-Base. *(x::MixedUnits, y::Number) = y * x
-Base. /(x::Number, y::MixedUnits) =
+Base.:*(x::Real, y::MixedUnits{Gain{L,S}}) where {L,S} = (Gain{L,S}(x))*y.units
+Base.:*(x::MixedUnits, y::Number) = y * x
+Base.:/(x::Number, y::MixedUnits) =
     throw(ArgumentError("cannot divide $x by logarithmic units."))
-Base. /(x::MixedUnits, y::Number) = inv(y) * x
+Base.:/(x::MixedUnits, y::Number) = inv(y) * x
 
 function uconvert(a::Units, x::Level)
     dimension(a) != dimension(x) && throw(DimensionError(a,x))
@@ -206,9 +206,9 @@ Base.hash(x::Level, h::UInt) = hash(x.val, h)
 
 # Addition and subtraction
 for op in (:+, :-)
-    @eval Base. $op(x::Level{L,S}, y::Level{L,S}) where {L,S} = Level{L,S}(($op)(x.val, y.val))
-    @eval Base. $op(x::Gain{L,S}, y::Gain{L,S}) where {L,S} = Gain{L,S}(($op)(x.val, y.val))
-    @eval function Base. $op(x::Gain{L,S1}, y::Gain{L,S2}) where {L,S1,S2}
+    @eval Base.$op(x::Level{L,S}, y::Level{L,S}) where {L,S} = Level{L,S}(($op)(x.val, y.val))
+    @eval Base.$op(x::Gain{L,S}, y::Gain{L,S}) where {L,S} = Gain{L,S}(($op)(x.val, y.val))
+    @eval function Base.$op(x::Gain{L,S1}, y::Gain{L,S2}) where {L,S1,S2}
         if S1 == :?
             return Gain{L,S2}(($op)(x.val, y.val))
         elseif S2 == :?
@@ -217,39 +217,39 @@ for op in (:+, :-)
             return Gain{L,:?}(($op)(x.val, y.val))
         end
     end
-    @eval Base. $op(x::Level{L,S}, y::Gain{L}) where {L,S} =
+    @eval Base.$op(x::Level{L,S}, y::Gain{L}) where {L,S} =
         Level{L,S}(fromlog(L, S, ($op)(ustrip(x), y.val)))
 end
-Base. +(x::Gain, y::Level) = +(y,x)
-Base. -(x::Gain, y::Level) = throw(ArgumentError("cannot subtract a level from a gain."))
+Base.:+(x::Gain, y::Level) = +(y,x)
+Base.:-(x::Gain, y::Level) = throw(ArgumentError("cannot subtract a level from a gain."))
 
 # Multiplication and division
 leveltype(x::Level{L,S}) where {L,S} = Level{L,S}
-Base. *(x::Level, y::Number) = (leveltype(x))(x.val * y)
-Base. *(x::Level, y::Bool) = (leveltype(x))(x.val * y)    # for method ambiguity
-Base. *(x::Level, y::AbstractQuantity) = *(x.val, y)
-Base. *(x::Level, y::Level) = *(x.val, y.val)
-Base. *(x::Level, y::Gain) = *(promote(x,y)...)
+Base.:*(x::Level, y::Number) = (leveltype(x))(x.val * y)
+Base.:*(x::Level, y::Bool) = (leveltype(x))(x.val * y)    # for method ambiguity
+Base.:*(x::Level, y::AbstractQuantity) = *(x.val, y)
+Base.:*(x::Level, y::Level) = *(x.val, y.val)
+Base.:*(x::Level, y::Gain) = *(promote(x,y)...)
 
-Base. *(x::Number, y::Level) = *(y,x)
-Base. *(x::Bool, y::Level) = *(y,x)                       # for method ambiguity
-Base. *(x::AbstractQuantity, y::Level) = *(y,x)           # for method ambiguity
+Base.:*(x::Number, y::Level) = *(y,x)
+Base.:*(x::Bool, y::Level) = *(y,x)                       # for method ambiguity
+Base.:*(x::AbstractQuantity, y::Level) = *(y,x)           # for method ambiguity
 
 gaintype(::Gain{L,S}) where {L,S} = Gain{L,S}
-Base. *(x::Gain, y::Number) = (gaintype(x))(x.val * y)
-Base. *(x::Gain, y::Bool) = (gaintype(x))(x.val * y)      # for method ambiguity
-Base. *(x::Gain, y::AbstractQuantity) = *(y,x)
-Base. *(x::Gain, y::Level) = *(promote(x,y)...)
-Base. *(x::Gain, y::Gain) = *(promote(x,y)...)
+Base.:*(x::Gain, y::Number) = (gaintype(x))(x.val * y)
+Base.:*(x::Gain, y::Bool) = (gaintype(x))(x.val * y)      # for method ambiguity
+Base.:*(x::Gain, y::AbstractQuantity) = *(y,x)
+Base.:*(x::Gain, y::Level) = *(promote(x,y)...)
+Base.:*(x::Gain, y::Gain) = *(promote(x,y)...)
 
-Base. *(x::Number, y::Gain) = *(y,x)
-Base. *(x::Bool, y::Gain) = *(y,x)                        # for method ambiguity
-Base. *(x::AbstractQuantity, y::Gain) =
+Base.:*(x::Number, y::Gain) = *(y,x)
+Base.:*(x::Bool, y::Gain) = *(y,x)                        # for method ambiguity
+Base.:*(x::AbstractQuantity, y::Gain) =
     isrootpower(x) ? uconvertrp(NoUnits, y) * x : uconvertp(NoUnits, y) * x
 
 for (op1,op2) in ((:*, :+), (:/, :-))
-    @eval Base. $op1(x::Gain{L,S}, y::Gain{L,S}) where {L,S} = Gain{L,S}(($op2)(x.val, y.val))
-    @eval function Base. $op1(x::Gain{L,S1}, y::Gain{L,S2}) where {L,S1,S2}
+    @eval Base.$op1(x::Gain{L,S}, y::Gain{L,S}) where {L,S} = Gain{L,S}(($op2)(x.val, y.val))
+    @eval function Base.$op1(x::Gain{L,S1}, y::Gain{L,S2}) where {L,S1,S2}
         if S1 == :?
             return Gain{L,S2}(($op2)(x.val, y.val))
         elseif S2 == :?
@@ -258,35 +258,35 @@ for (op1,op2) in ((:*, :+), (:/, :-))
             return Gain{L,:?}(($op2)(x.val, y.val))
         end
     end
-    @eval Base. $op1(x::Level{L,S}, y::Gain{L}) where {L,S} =
+    @eval Base.$op1(x::Level{L,S}, y::Gain{L}) where {L,S} =
         Level{L,S}(fromlog(L, S, ($op2)(ustrip(x), y.val)))
 end
 
-Base. *(x::Gain{L}, y::Level{L,S}) where {L,S} = Level{L,S}(fromlog(L, S, ustrip(y)+x.val))
-Base. /(x::Gain, y::Level) = throw(ArgumentError("cannot divide a gain by a level."))
+Base.:*(x::Gain{L}, y::Level{L,S}) where {L,S} = Level{L,S}(fromlog(L, S, ustrip(y)+x.val))
+Base.:/(x::Gain, y::Level) = throw(ArgumentError("cannot divide a gain by a level."))
 
-Base. /(x::Level, y::Number) = (leveltype(x))(linear(x) / y)
-Base. //(x::Level, y::Number) = (leveltype(x))(linear(x) // y)
-Base. /(x::Level, y::AbstractQuantity) = linear(x) / y
-Base. //(x::Level, y::AbstractQuantity) = linear(x) // y
-Base. /(x::Level, y::Level) = linear(x) / linear(y)
-Base. //(x::Level, y::Level) = linear(x) // linear(y)
-Base. //(x::Level, y::Complex) = linear(x) // y     # ambiguity resolution
+Base.:/(x::Level, y::Number) = (leveltype(x))(linear(x) / y)
+Base.://(x::Level, y::Number) = (leveltype(x))(linear(x) // y)
+Base.:/(x::Level, y::AbstractQuantity) = linear(x) / y
+Base.://(x::Level, y::AbstractQuantity) = linear(x) // y
+Base.:/(x::Level, y::Level) = linear(x) / linear(y)
+Base.://(x::Level, y::Level) = linear(x) // linear(y)
+Base.://(x::Level, y::Complex) = linear(x) // y     # ambiguity resolution
 
-Base. //(x::Number, y::Level) = x // linear(y)
-Base. /(x::AbstractQuantity, y::Level) = x / linear(y)
-Base. //(x::AbstractQuantity, y::Level) = x // linear(y)
-Base. /(x::AbstractQuantity, y::Gain) =
+Base.://(x::Number, y::Level) = x // linear(y)
+Base.:/(x::AbstractQuantity, y::Level) = x / linear(y)
+Base.://(x::AbstractQuantity, y::Level) = x // linear(y)
+Base.:/(x::AbstractQuantity, y::Gain) =
     isrootpower(x) ? x / uconvertrp(NoUnits, y) : x / uconvertp(NoUnits, y)
-Base. //(x::AbstractQuantity, y::Gain) =
+Base.://(x::AbstractQuantity, y::Gain) =
     isrootpower(x) ? x // uconvertrp(NoUnits, y) : x // uconvertp(NoUnits, y)
 
-Base. //(x::Level, y::Units) = x/y
-Base. //(x::Units, y::Level) = x//linear(y)
-Base. //(x::Gain, y::Units) = x/y
-Base. //(x::Units, y::Gain) = x//linear(y)
+Base.://(x::Level, y::Units) = x/y
+Base.://(x::Units, y::Level) = x//linear(y)
+Base.://(x::Gain, y::Units) = x/y
+Base.://(x::Units, y::Gain) = x//linear(y)
 
-Base. isless(x::T, y::T) where {T<:LogScaled} = isless(x.val, y.val)
+Base.isless(x::T, y::T) where {T<:LogScaled} = isless(x.val, y.val)
 
 function (Base.promote_rule(::Type{Level{L1,S1,T1}}, ::Type{Level{L2,S2,T2}})
         where {L1,L2,S1,S2,T1,T2})


### PR DESCRIPTION
This is currently causing parsing errors in v1.13. This may be fixed upstream, but these extra spaces look odd anyway, we can just remove them.

Fix #815.