### PR TITLE
Fix isapprox for dimensionless Quantity vs Number with atol

### DIFF
--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -263,7 +263,13 @@ function isapprox(x::AbstractQuantity, y::AbstractQuantity; kwargs...)
     return isapprox(promote(x,y)...; kwargs...)
 end
 
-isapprox(x::AbstractQuantity, y::Number; kwargs...) = isapprox(promote(x,y)...; kwargs...)
+function isapprox(x::AbstractQuantity, y::Number; atol=nothing, kwargs...)
+    if atol === nothing
+        return isapprox(promote(x, y)...; kwargs...)
+    end
+    xp, yp, atolp = promote(x, y, atol)
+    return isapprox(xp, yp; atol=atolp, kwargs...)
+end
 isapprox(x::Number, y::AbstractQuantity; kwargs...) = isapprox(y, x; kwargs...)
 
 function isapprox(
@@ -287,9 +293,13 @@ isapprox(x::AbstractArray{S}, y::AbstractArray{T};
     kwargs...) where {S <: AbstractQuantity,T <: AbstractQuantity} = false
 
 function isapprox(x::AbstractArray{S}, y::AbstractArray{N};
-    kwargs...) where {S <: AbstractQuantity,N <: Number}
+    atol=nothing, kwargs...) where {S <: AbstractQuantity,N <: Number}
     if dimension(N) == dimension(S)
-        isapprox(map(x->uconvert(NoUnits,x),x),y; kwargs...)
+        if atol === nothing
+            isapprox(map(x->uconvert(NoUnits,x),x), y; kwargs...)
+        else
+            isapprox(map(x->uconvert(NoUnits,x),x), y; atol = ustrip(NoUnits, atol), kwargs...)
+        end
     else
         false
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -969,6 +969,13 @@ Base.:(<=)(x::Issue399, y::Issue399) = x.num <= y.num
         @test isapprox(1.0u"m", 1.1u"m"; rtol=0.2)
         @test !isapprox(1.0u"m", 1.1u"m"; rtol=0.05)
 
+        # isapprox with dimensionless Quantity vs Number and atol
+        @test isapprox(1u"rad", 1.1; atol=0.5u"rad")
+        @test !isapprox(1u"rad", 1.1; atol=0.01u"rad")
+        @test isapprox(1.1, 1u"rad"; atol=0.5u"rad")
+        @test isapprox(1.0u"rad", 1.1; atol=0.5)
+        @test isapprox(1.0u"rad", 1.01; rtol=0.1)
+
         # Issue 465:
         z = fill((1+im)m, 2, 3)
         @test !isapprox(z, 2z)
@@ -1657,6 +1664,7 @@ end
             @test !isapprox([1.0m, NaN*m], [nextfloat(1.0)*m, NaN*m], nans=false)
             @test !isapprox([1.0m, 2.0m], [1.1m, 2.2m], rtol=0.05, atol=0.2m)
             @test !isapprox([1.0m], [nextfloat(1.0)*m], atol=eps(0.1)*m)
+            @test isapprox([1.0u"rad"], [1.1]; atol=0.5u"rad")
         end
         @testset ">> Unit stripping" begin
             @test @inferred(ustrip([1u"m", 2u"m"])) == [1,2]


### PR DESCRIPTION
## Summary

- `isapprox(1u"rad", 1.1; atol=0.5u"rad")` threw `TypeError` because `promote` strips units from dimensionless quantities but `atol` was passed through unchanged to `Base.isapprox` which requires `atol::Real`
- Fix scalar method by promoting `atol` together with the arguments, so it gets the same unit-stripping treatment
- Fix array method by stripping `atol` units via `ustrip(NoUnits, atol)` when converting Quantity arrays to plain numbers

## Test plan

- [x] Added tests for dimensionless Quantity vs Number with Quantity `atol`, reversed argument order, plain Number `atol`, `rtol`, and the array case
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)