### PR TITLE
Fix unit promotion for same units, different context

### DIFF
--- a/src/promotion.jl
+++ b/src/promotion.jl
@@ -28,7 +28,7 @@ promote_unit(x::Units, y::Units, z::Units, t::Units...) =
 @inline _promote_unit(x::ContextUnits{N,D,P,A}, y::ContextUnits{N,D,P,A}) where {N,D,P,A} = x  #ambiguity reasons
 # same units, but promotion context disagrees
 @inline _promote_unit(x::ContextUnits{N,D,P1,A}, y::ContextUnits{N,D,P2,A}) where {N,D,P1,P2,A} =
-    ContextUnits{N,D,promote_unit(P1(), P2()),A}()
+    ContextUnits{N,D,typeof(promote_unit(P1(), P2())),A}()
 # different units, but promotion context agrees
 @inline _promote_unit(x::ContextUnits{N1,D,P}, y::ContextUnits{N2,D,P}) where {N1,N2,D,P} =
     ContextUnits(P(), P())

--- a/src/promotion.jl
+++ b/src/promotion.jl
@@ -26,13 +26,10 @@ promote_unit(x::Units, y::Units, z::Units, t::Units...) =
     upreferred(dimension(x))
 
 @inline _promote_unit(x::ContextUnits{N,D,P,A}, y::ContextUnits{N,D,P,A}) where {N,D,P,A} = x  #ambiguity reasons
-# same units, but promotion context disagrees
-@inline _promote_unit(x::ContextUnits{N,D,P1,A}, y::ContextUnits{N,D,P2,A}) where {N,D,P1,P2,A} =
-    ContextUnits{N,D,typeof(promote_unit(P1(), P2())),A}()
 # different units, but promotion context agrees
 @inline _promote_unit(x::ContextUnits{N1,D,P}, y::ContextUnits{N2,D,P}) where {N1,N2,D,P} =
     ContextUnits(P(), P())
-# different units, promotion context disagrees, fall back to FreeUnits
+# same or different units, promotion context disagrees, fall back to FreeUnits
 @inline _promote_unit(x::ContextUnits{N1,D,P1}, y::ContextUnits{N2,D,P2}) where {N1,N2,D,P1,P2} =
     promote_unit(FreeUnits(x), FreeUnits(y))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -545,6 +545,9 @@ Unitful.uconvert(U::Unitful.Units, q::QQQ) = uconvert(U, Quantity(q.val, cm))
             (1.0μm2μm, 1.0nm2μm, 1.0s)
         # Context disagreement: fall back to free units
         @test @inferred(promote(1.0nm2μm, 1.0μm2mm)) === (1e-9m, 1e-6m)
+        # Same units, context disagreement
+        μm2m = ContextUnits(μm, m)
+        @test @inferred(promote(1.0μm2μm, 1.0μm2mm)) === (1.0μm2m, 1.0μm2m)
     end
     @testset "> Promotion during array creation" begin
         @test typeof([1.0m,1.0m]) == Array{typeof(1.0m),1}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -546,8 +546,7 @@ Unitful.uconvert(U::Unitful.Units, q::QQQ) = uconvert(U, Quantity(q.val, cm))
         # Context disagreement: fall back to free units
         @test @inferred(promote(1.0nm2μm, 1.0μm2mm)) === (1e-9m, 1e-6m)
         # Same units, context disagreement
-        μm2m = ContextUnits(μm, m)
-        @test @inferred(promote(1.0μm2μm, 1.0μm2mm)) === (1.0μm2m, 1.0μm2m)
+        @test @inferred(promote(1.0μm2μm, 1.0μm2mm)) === (1.0μm, 1.0μm)
     end
     @testset "> Promotion during array creation" begin
         @test typeof([1.0m,1.0m]) == Array{typeof(1.0m),1}


### PR DESCRIPTION
Unit promotion for "same units but different promotion context" uses a unit singleton instance as a type parameter, but it should use the type.

Example:

```julia
import Unitful: μm, mm, ContextUnits
μm2μm = ContextUnits(μm,μm)
μm2mm = ContextUnits(μm,mm)
x, y = promote(1.0μm2μm, 1.0μm2mm)
upreferred(x)
```

Before the fix:

```
ERROR: MethodError: no method matching (::Unitful.FreeUnits{(m,), 𝐋, nothing})()
```

After the fix:
```
1.0e-6 m
```