### PR TITLE
Fix boxing in `show` `Unitlike`

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -169,12 +169,12 @@ variable of a [`Unitful.Units`](@ref) or [`Unitful.Dimensions`](@ref) object.
 """
 function show(io::IO, x::Unitlike)
     showoperators = get(io, :showoperators, false)
-    first = ""
     sep = showoperators ? "*" : " "
-    foreach(sortexp(x)) do y
-        print(io,first)
-        showrep(io,y)
-        first = sep
+    isfirst = true
+    for y in sortexp(x)
+        isfirst || print(io, sep)
+        showrep(io, y)
+        isfirst = false
     end
     nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1751,6 +1751,10 @@ end
         @test sprint(io -> show(IOContext(io, :fancy_exponent => true), u"m/s")) == "m s⁻¹"
         @test sprint(io -> show(IOContext(io, :fancy_exponent => false), u"m/s")) == "m s^-1"
     end
+    @testset "no Core.Box in show(::IO, ::Unitlike)" begin
+        # Regression: the old implementation used a closure that reassigned an outer local, forcing the variable to be wrapped in a `Core.Box`. That hurt inference (variable inferred as `Core.Box` instead of `String`) and triggered "local variable `first` is not defined" reports from static analyzers like JET.
+        @test !any(==(Core.Box), only(code_typed(show, Tuple{IO, typeof(u"m")}; optimize=false)).first.slottypes)
+    end
 end
 
 struct Foo <: Number end


### PR DESCRIPTION
The current implementation defines `first` outside of the `do` closure and writes to in inside of the closure creating the infamous box. The resulting lack of inference leads to a JET error.

To avoid this, rewrite the method to not use a closure. The resulting code has the same readability, but no boxing and is ~10% faster in my tests with a reduced allocation.