### PR TITLE
Add UnitfulGauss.jl to the list of Units packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ mathematical operations and collections that are found in Julia base.
 - [UnitfulAtomic.jl](https://github.com/sostock/UnitfulAtomic.jl): Easy conversion from and to atomic units.
 - [PowerSystemsUnits.jl](https://github.com/invenia/PowerSystemsUnits.jl): Common units for dealing with power systems.
 - [UnitfulMoles.jl](https://github.com/rafaqz/UnitfulMoles.jl) for defining mol units of chemical elements and compounds.
+- [UnitfulGauss.jl](https://github.com/Gregstrq/UnitfulGauss.jl): Gaussian electromagnetic units with proper gaussian physical dimensions.
 
 ### Feature additions
 


### PR DESCRIPTION
I have just registered a package [UnitfulGauss.jl](https://github.com/Gregstrq/UnitfulGauss.jl) that defines the gaussian EM units with proper dimensions, that is based on Unitful, and would like to add it to the README.

Besides the units, the package defines a couple of convenience functions (`@ug_str` macro that mimics `@u_str` but chooses the right gaussian units, and conversion utilities between SI and gaussian physical dimensions.)